### PR TITLE
Expanded opcodes

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -11,7 +11,7 @@
 |     6     | Privileged Mode                                           | 2            | Planned           |
 |     7     | Cache Instructions                                        | VWI          | Planned           |
 |     8     | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | 1            | Under Development |
-|     9     | Expanded Opcodes                                          | VWI          | Planned           |
+|     9     | [Expanded Opcodes](./expanded-opcodes)                    | VWI          | Under Development |
 |     14    | [32 Bit Operations + Registers](./double-word-operations) | None         | Under Development |
 |     15    | [64 Bit Operations + Registers](./quad-word-operations)   | None         | Under Development |
 |     16    | 32 Bit Address Space                                      | 14           | Planned           |

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -11,77 +11,52 @@ This extension adds an expanded instruction format to allow for a larger number 
 
 # Added Instructions
 
-The following opcodes are now defined.
+## Calculation Instructions
 
-| First byte    | Second Byte  | Third Byte   | Comment                                                                   |
-|:--------------|:-------------|:-------------|:--------------------------------------------------------------------------|
-| `111 00 000`  | `SS CCCCCC`  | `RRR RRR MM` | Register-Register operation                                               |
-| `111 00 ???`  | `SS CCCCCC`  | `RRR RRR MM` | When `???` is not `000`, reserved                                         |
-| `111 01 000`  | `SS CCCCCC`  | `RRR IIIII`  | Register-Immediate operation                                              |
-| `111 01 ???`  | `SS CCCCCC`  | `RRR IIIII`  | When `???` is not `000`, reserved                                         |
-| `111 10 DDD`  | `DDDD DDDD`  | `DDDD DDDD`  | Large relative jump                                                       |
-| `111 11 DDD`  | `DDDD DDDD`  | `DDDD DDDD`  | Large relative call if stack extension is implemented, otherwise reserved |
+| First byte    | Second Byte   | Third Byte   | Comment                      |
+|:--------------|:--------------|:-------------|:-----------------------------|
+| `111 0 CCCC`  | `C 0 SS CCCC` | `RRR RRR MM` | Register-Register operation  |
+| `111 0 CCCC`  | `C 1 SS CCCC` | `RRR IIIII`  | Register-Immediate operation |
 
 | Symbol | Meaning                                    |
 |--------|--------------------------------------------|
-| C      | condition code bit                         |
+| C      | opcode bit                                 |
 | R      | register id                                |
 | I      | immediate                                  |
-| D      | signed displacement                        |
 | S      | size                                       |
 | M      | memory mode                                |
-| ?      | reserved for extensions or another purpose |
 
-## Mapping from the base ISA opcodes to this extension
+### Opcode table
 
-When the base opcode `CCCC` matches `0xxx`, the new opcode is `0 CCCC 0`
-
-When the base opcode `CCCC` matches `1xxx`, the new opcode is `01 CCCC`
-
-## Opcode mapping table
-
-| `CCCCCC` | NAME            | Operation                          | Flags  | Comment     |
-|----------|-----------------|------------------------------------|--------|-------------|
-| `000000` | `ADD`           | `A ← A + B`                        | `ZNCV` |             |
-| `000001` | `ADC`           | `A ← A + B + C`                    | `ZNCV` |             |
-| `000010` | `SUB`           | `A ← A - B`                        | `ZNCV` |             |
-| `000011` | `SBB`           | `A ← A - B - C`                    | `ZNCV` |             |
-| `000100` | `RSUB`          | `A ← B - A`                        | `ZNCV` | (1)         |
-| `000101` | `RSBB`          | `A ← B - A - C`                    | `ZNCV` |             |
-| `000110` | `CMP`           | `_ ← A - B`                        | `ZNCV` |             |
-| `000111` | `RCMP`          | `_ ← B - A`                        | `ZNCV` |             |
-| `001000` | `OR`            | <code>A ← A &#124; B</code>        | `ZN`   | (5)         |
-| `001001` | `NOR`           | <code>A ← ~(A &#124; B)</code>     | `ZN`   | (5)         |
-| `001010` | `XOR`           | `A ← A ^ B`                        | `ZN`   | (5)         |
-| `001011` | `XNOR`          | `A ← ~(A ^ B)`                     | `ZN`   | (5)         |
-| `001100` | `AND`           | `A ← A & B`                        | `ZN`   | (5)         |
-| `001101` | `NAND`          | `A ← ~(A & B)`                     | `ZN`   | (5)         |
-| `001110` | `TEST`          | `_ ← A & B`                        | `ZN`   | (5)         |
-| `001111` |                 |                                    |        | reserved    |
-| `010000` | `SHL`           | `A ← A << B`                       | `ZN`   | (5)         |
-| `010001` | `ROL`           | `A ← A rotate left B`              | `ZN`   | (5)         |
-| `010010` | `LSHR`          | `A ← A >>> B`                      | `ZN`   | (5)         |
-| `010011` | `ASHR`          | `A ← A >> B`                       | `ZN`   | (5)         |
-| `010100` |                 |                                    |        | reserved    |
-| `010101` |                 |                                    |        | reserved    |
-| `010110` |                 |                                    |        | reserved    |
-| `010111` |                 |                                    |        | reserved    |
-| `011000` | `MOVZ`          | `A ← B`                            | None   | (7)         |
-| `011001` | `MOV` or `MOVS` | `A ← B`                            | None   | (8)         |
-| `011010` | `LOAD`          | `A ← MEM[B]`                       | None   |             |
-| `011011` | `STORE`         | `MEM[B] ← A`                       | None   | (2)         |
-| `011100` | `SLO`           | <code>A ← (A << 5) &#124; B</code> | None   | (3) (6)     |
-| `011101` |                 |                                    |        | reserved    |
-| `011110` | `READCR`        | `A ← CR[B]`                        | None   | (4) (6)     |
-| `011111` | `WRITECR`       | `CR[B] ← A`                        | None   | (2) (4) (6) |
-| `1xxxxx` |                 |                                    |        | reserved    |
+| `C CCCC CCCC` | NAME            | Operation                          | Flags  | Comment     |
+|---------------|-----------------|------------------------------------|--------|-------------|
+| `0 0000 0000` | `ADC`           | `A ← A + B + C`                    | `ZNCV` | (2)         |
+| `0 0000 0001` | `SBB`           | `A ← A - B - C`                    | `ZNCV` | (2)         |
+| `0 0000 0010` | `RSBB`          | `A ← B - A - C`                    | `ZNCV` | (1) (2)     |
+| `0 0000 0011` |                 |                                    |        | reserved    |
+| `0 0000 01xx` |                 |                                    |        | reserved    |
+| `0 0000 1xxx` |                 |                                    |        | reserved    |
+| `0 0001 xxxx` |                 |                                    |        | reserved    |
+| `0 001x xxxx` |                 |                                    |        | reserved    |
+| `0 01xx xxxx` |                 |                                    |        | reserved    |
+| `0 1xxx xxxx` |                 |                                    |        | reserved    |
+| `1 xxxx xxxx` |                 |                                    |        | reserved    |
 
 
-1) Enables NEG and NOT to be encoded as `RSUB r, imm`.
-3) Designed to allow for building a larger immediate value. To reach a full 16 bit immediate, a 4th `SLO` or an additional `NOT` may be required.
-4) Primary intent is that these are used with immediate. Exact assignment of control registers is still floating. At least the the CPU status/extension/feature control registers should be present.
-5) The C and O flags are in an undefined state after execution of these instructions. Implementations may do whatever is easiest. An extension may mandate a particular behavior, with good enough reason, but must *not* mandate that the value of these flags after the operation depends on their value before the operation.
-6) These instructions do not have a 2 register mode.
-7) This instruction zero extends argument B as if the value read is of the size specified by the SS bits in the instruction (assuming the relevant feature is present)
-8) This instruction sign extends argument B as if the value read is of the size specified by the SS bits in the instruction (assuming the relevant feature is present)
+1) Enables NEG and NOT to be encoded as `RSBB r, imm` for integers larger than supported by the ISA.
+2) C in the operation refers to the carry bit.
+
+## Jump and Call
+
+| First byte   | 2nd-9th Byte | Comment                                                             |
+|:-------------|:-------------|:--------------------------------------------------------------------|
+| `111 10 JJJ` | `DDDD DDDD`  | Relative jump                                                       |
+| `111 11 JJJ` | `DDDD DDDD`  | Relative call if stack extension is implemented, otherwise reserved |
+
+| Symbol | Meaning                                         |
+|--------|-------------------------------------------------|
+| J      | the number of bytes to use for the displacement |
+| D      | signed displacement                             |
+
+`JJJ` is 1 less than the number of bytes to use for the displacement. This means that `JJJ = 000` is 1 additional byte and `JJJ = 111` is 8 additional bytes.
 

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -50,18 +50,18 @@ This extension adds an expanded instruction format to allow for a larger number 
 
 | First byte    | 2nd-9th Byte | Comment                                                             |
 |:--------------|:-------------|:--------------------------------------------------------------------|
-| `111 10 0 JJ` | `DDDD DDDD`  | Relative jump                                                       |
-| `111 10 1 JJ` | `IIII IIII`  | Absolute jump                                                       |
-| `111 11 0 JJ` | `DDDD DDDD`  | Relative call if stack extension is implemented, otherwise reserved |
-| `111 11 1 JJ` | `IIII IIII`  | Absolute call if stack extension is implemented, otherwise reserved |
+| `111 10 0 SS` | `DDDD DDDD`  | Relative jump                                                       |
+| `111 10 1 SS` | `IIII IIII`  | Absolute jump                                                       |
+| `111 11 0 SS` | `DDDD DDDD`  | Relative call if stack extension is implemented, otherwise reserved |
+| `111 11 1 SS` | `IIII IIII`  | Absolute call if stack extension is implemented, otherwise reserved |
 
 | Symbol | Meaning                                         |
 |--------|-------------------------------------------------|
-| J      | the number of bytes to use for the displacement |
+| S      | the number of bytes to use for the displacement |
 | D      | signed displacement                             |
 | I      | unsigned immediate                              |
 
-`JJ` is log base 2 of the number of bytes to use for the displacement. This means that `JJ = 00` is 1 additional byte and `JJ = 11` is 8 additional bytes.
+`SS = 00,01,10,11` means that read 1,2,4,8 additional bytes as the signed displacement.
 
 Absolute jumps only overwrite the lower bits of the program counter.
 

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -60,8 +60,8 @@ When the base opcode `CCCC` matches `1xxx`, the new opcode is `01 CCCC`
 | `001111` |                 |                                    |        | reserved    |
 | `010000` | `SHL`           | `A ← A << B`                       | `ZN`   | (5)         |
 | `010001` | `ROL`           | `A ← A rotate left B`              | `ZN`   | (5)         |
-| `010010` | `LSHR`          | `A ← A >> B`                       | `ZN`   | (5)         |
-| `010011` | `ASHR`          | `A ← A >>> B`                      | `ZN`   | (5)         |
+| `010010` | `LSHR`          | `A ← A >>> B`                      | `ZN`   | (5)         |
+| `010011` | `ASHR`          | `A ← A >> B`                       | `ZN`   | (5)         |
 | `010100` |                 |                                    |        | reserved    |
 | `010101` |                 |                                    |        | reserved    |
 | `010110` |                 |                                    |        | reserved    |

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -1,0 +1,87 @@
+# General design
+
+**Extension State: Under Development**  
+**Enabled by Default: Yes**  
+**Requires: Base, VWI**  
+**CPUID Bit: 9**
+
+# Overview
+
+This extension adds an expanded instruction format to allow for a larger number of opcodes to be used. It also includes a relative jump and call with larger displacements.
+
+# Added Instructions
+
+The following opcodes are now defined.
+
+| First byte    | Second Byte  | Third Byte   | Comment                                                                   |
+|:--------------|:-------------|:-------------|:--------------------------------------------------------------------------|
+| `111 00 000`  | `SS CCCCCC`  | `RRR RRR MM` | Register-Register operation                                               |
+| `111 00 ???`  | `SS CCCCCC`  | `RRR RRR MM` | When `???` is not `000`, reserved                                         |
+| `111 01 000`  | `SS CCCCCC`  | `RRR IIIII`  | Register-Immediate operation                                              |
+| `111 01 ???`  | `SS CCCCCC`  | `RRR IIIII`  | When `???` is not `000`, reserved                                         |
+| `111 10 DDD`  | `DDDD DDDD`  | `DDDD DDDD`  | Large relative jump                                                       |
+| `111 11 DDD`  | `DDDD DDDD`  | `DDDD DDDD`  | Large relative call if stack extension is implemented, otherwise reserved |
+
+| Symbol | Meaning                                    |
+|--------|--------------------------------------------|
+| C      | condition code bit                         |
+| R      | register id                                |
+| I      | immediate                                  |
+| D      | signed displacement                        |
+| S      | size                                       |
+| M      | memory mode                                |
+| ?      | reserved for extensions or another purpose |
+
+## Mapping from the base ISA opcodes to this extension
+
+When the base opcode `CCCC` matches `0xxx`, the new opcode is `0 CCCC 0`
+
+When the base opcode `CCCC` matches `1xxx`, the new opcode is `01 CCCC`
+
+## Opcode mapping table
+
+| `CCCCCC` | NAME            | Operation                          | Flags  | Comment     |
+|----------|-----------------|------------------------------------|--------|-------------|
+| `000000` | `ADD`           | `A ← A + B`                        | `ZNCV` |             |
+| `000001` | `ADC`           | `A ← A + B + C`                    | `ZNCV` |             |
+| `000010` | `SUB`           | `A ← A - B`                        | `ZNCV` |             |
+| `000011` | `SBB`           | `A ← A - B - C`                    | `ZNCV` |             |
+| `000100` | `RSUB`          | `A ← B - A`                        | `ZNCV` | (1)         |
+| `000101` | `RSBB`          | `A ← B - A - C`                    | `ZNCV` |             |
+| `000110` | `CMP`           | `_ ← A - B`                        | `ZNCV` |             |
+| `000111` | `RCMP`          | `_ ← B - A`                        | `ZNCV` |             |
+| `001000` | `OR`            | <code>A ← A &#124; B</code>        | `ZN`   | (5)         |
+| `001001` | `NOR`           | <code>A ← ~(A &#124; B)</code>     | `ZN`   | (5)         |
+| `001010` | `XOR`           | `A ← A ^ B`                        | `ZN`   | (5)         |
+| `001011` | `XNOR`          | `A ← ~(A ^ B)`                     | `ZN`   | (5)         |
+| `001100` | `AND`           | `A ← A & B`                        | `ZN`   | (5)         |
+| `001101` | `NAND`          | `A ← ~(A & B)`                     | `ZN`   | (5)         |
+| `001110` | `TEST`          | `_ ← A & B`                        | `ZN`   | (5)         |
+| `001111` |                 |                                    |        | reserved    |
+| `010000` | `SHL`           | `A ← A << B`                       | `ZN`   | (5)         |
+| `010001` | `ROL`           | `A ← A rotate left B`              | `ZN`   | (5)         |
+| `010010` | `LSHR`          | `A ← A >> B`                       | `ZN`   | (5)         |
+| `010011` | `ASHR`          | `A ← A >>> B`                      | `ZN`   | (5)         |
+| `010100` |                 |                                    |        | reserved    |
+| `010101` |                 |                                    |        | reserved    |
+| `010110` |                 |                                    |        | reserved    |
+| `010111` |                 |                                    |        | reserved    |
+| `011000` | `MOVZ`          | `A ← B`                            | None   | (7)         |
+| `011001` | `MOV` or `MOVS` | `A ← B`                            | None   | (8)         |
+| `011010` | `LOAD`          | `A ← MEM[B]`                       | None   |             |
+| `011011` | `STORE`         | `MEM[B] ← A`                       | None   | (2)         |
+| `011100` | `SLO`           | <code>A ← (A << 5) &#124; B</code> | None   | (3) (6)     |
+| `011101` |                 |                                    |        | reserved    |
+| `011110` | `READCR`        | `A ← CR[B]`                        | None   | (4) (6)     |
+| `011111` | `WRITECR`       | `CR[B] ← A`                        | None   | (2) (4) (6) |
+| `1xxxxx` |                 |                                    |        | reserved    |
+
+
+1) Enables NEG and NOT to be encoded as `RSUB r, imm`.
+3) Designed to allow for building a larger immediate value. To reach a full 16 bit immediate, a 4th `SLO` or an additional `NOT` may be required.
+4) Primary intent is that these are used with immediate. Exact assignment of control registers is still floating. At least the the CPU status/extension/feature control registers should be present.
+5) The C and O flags are in an undefined state after execution of these instructions. Implementations may do whatever is easiest. An extension may mandate a particular behavior, with good enough reason, but must *not* mandate that the value of these flags after the operation depends on their value before the operation.
+6) These instructions do not have a 2 register mode.
+7) This instruction zero extends argument B as if the value read is of the size specified by the SS bits in the instruction (assuming the relevant feature is present)
+8) This instruction sign extends argument B as if the value read is of the size specified by the SS bits in the instruction (assuming the relevant feature is present)
+

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -48,15 +48,20 @@ This extension adds an expanded instruction format to allow for a larger number 
 
 ## Jump and Call
 
-| First byte   | 2nd-9th Byte | Comment                                                             |
-|:-------------|:-------------|:--------------------------------------------------------------------|
-| `111 10 JJJ` | `DDDD DDDD`  | Relative jump                                                       |
-| `111 11 JJJ` | `DDDD DDDD`  | Relative call if stack extension is implemented, otherwise reserved |
+| First byte    | 2nd-9th Byte | Comment                                                             |
+|:--------------|:-------------|:--------------------------------------------------------------------|
+| `111 10 0 JJ` | `DDDD DDDD`  | Relative jump                                                       |
+| `111 10 1 JJ` | `IIII IIII`  | Absolute jump                                                       |
+| `111 11 0 JJ` | `DDDD DDDD`  | Relative call if stack extension is implemented, otherwise reserved |
+| `111 11 1 JJ` | `IIII IIII`  | Absolute call if stack extension is implemented, otherwise reserved |
 
 | Symbol | Meaning                                         |
 |--------|-------------------------------------------------|
 | J      | the number of bytes to use for the displacement |
 | D      | signed displacement                             |
+| I      | unsigned immediate                              |
 
-`JJJ` is 1 less than the number of bytes to use for the displacement. This means that `JJJ = 000` is 1 additional byte and `JJJ = 111` is 8 additional bytes.
+`JJ` is log base 2 of the number of bytes to use for the displacement. This means that `JJ = 00` is 1 additional byte and `JJ = 11` is 8 additional bytes.
+
+Absolute jumps only overwrite the lower bits of the program counter.
 


### PR DESCRIPTION
A few things to think about for this PR.

1. Do we want to remove the expanded registers extension and integrate it through the current reserved bits?
   -  We could also reclaim the prefixes reserved in the `110x xxxx` area and add an additional C or reserved bit if we think that's a good idea.
2. Are `rsbb` and `rcmp` useful?
3. Do we want the shifts and added bitwise functions here or in another extension?

Depending on what you all think, I may or may not move some of the sections around a bit