### PR TITLE
Remove exten control register and add second cpuid control register

### DIFF
--- a/base-isa.md
+++ b/base-isa.md
@@ -97,11 +97,11 @@ TODO: This is a baseline, very much still floating
 
 Undefined control registers are reserved and reading from or writing to them is undefined behavior.
 
-| `CRN`  | NAME       | Description                                                                                                                            | Comment |
-|--------|------------|----------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `0000` | `CPUID1`   | Reading from this control register puts the first set of available CPU extensions in the destination register. Writing to it is a NOP  | (1)     |
-| `0001` | `CPUID2`   | Reading from this control register puts the second set of available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
-| `0010` | `FEAT`     | Reading from this control register puts the available CPU features in the destination register. Writing to it is a NOP                 | (2)     |
+| `CRN`  | NAME       | Description                                                                                                                             | Comment |
+|--------|------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `0000` | `CPUID1`   | Reading from this control register puts the first set of available CPU extensions in the destination register. Writing to it is a NOP.  | (1)     |
+| `0001` | `CPUID2`   | Reading from this control register puts the second set of available CPU extensions in the destination register. Writing to it is a NOP. | (1)     |
+| `0010` | `FEAT`     | Reading from this control register puts the available CPU features in the destination register. Writing to it is a NOP.                 | (2)     |
 
 1) CPUID uses a bitfield to specify the available extensions. A value of 0 means no extensions are available.
 2) FEAT uses a bitfield to specify the available features. A value of 0 means no features are available.

--- a/base-isa.md
+++ b/base-isa.md
@@ -97,11 +97,11 @@ TODO: This is a baseline, very much still floating
 
 Undefined control registers are reserved and reading from or writing to them is undefined behavior.
 
-| `CRN`  | NAME       | Description                                                                                                              | Comment |
-|--------|------------|--------------------------------------------------------------------------------------------------------------------------|---------|
-| `0000` | `CPUID1`   | Reading from this control register puts the available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
-| `0001` | `CPUID2`   | Reading from this control register puts the available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
-| `0010` | `FEAT`     | Reading from this control register puts the available CPU features in the destination register. Writing to it is a NOP   | (2)     |
+| `CRN`  | NAME       | Description                                                                                                                            | Comment |
+|--------|------------|----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `0000` | `CPUID1`   | Reading from this control register puts the first set of available CPU extensions in the destination register. Writing to it is a NOP  | (1)     |
+| `0001` | `CPUID2`   | Reading from this control register puts the second set of available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
+| `0010` | `FEAT`     | Reading from this control register puts the available CPU features in the destination register. Writing to it is a NOP                 | (2)     |
 
 1) CPUID uses a bitfield to specify the available extensions. A value of 0 means no extensions are available.
 2) FEAT uses a bitfield to specify the available features. A value of 0 means no features are available.

--- a/base-isa.md
+++ b/base-isa.md
@@ -99,13 +99,12 @@ Undefined control registers are reserved and reading from or writing to them is 
 
 | `CRN`  | NAME       | Description                                                                                                              | Comment |
 |--------|------------|--------------------------------------------------------------------------------------------------------------------------|---------|
-| `0000` | `CPUID`    | Reading from this control register puts the available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
-| `0001` | `EXTEN`    | This control register specifies which available extensions are enabled or disabled.                                      | (2)     |
-| `0010` | `FEAT`     | Reading from this control register puts the available CPU features in the destination register. Writing to it is a NOP   | (3)     |
+| `0000` | `CPUID1`   | Reading from this control register puts the available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
+| `0001` | `CPUID2`   | Reading from this control register puts the available CPU extensions in the destination register. Writing to it is a NOP | (1)     |
+| `0010` | `FEAT`     | Reading from this control register puts the available CPU features in the destination register. Writing to it is a NOP   | (2)     |
 
 1) CPUID uses a bitfield to specify the available extensions. A value of 0 means no extensions are available.
-2) This uses a bitfield in the same format as CPUID. Attempting to enable a non-available extension should leave the bit cleared. Attempting to disable a non-disableable extension should leave the bit set.
-3) FEAT uses a bitfield to specify the available features. A value of 0 means no features are available.
+2) FEAT uses a bitfield to specify the available features. A value of 0 means no features are available.
 
 ## Memory Semantics
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,31 +1,31 @@
 # Extensions
 
-| CPUID1 bit | Extension                                                 | Dependencies | State             |
-|:----------:|-----------------------------------------------------------|:------------:|-------------------|
-|     0      | [Full Immediate](./full-immediates)                       | VWI          | Under Development |
-|     1      | [Stack & Functions](./stack-and-functions)                | None         | Under Development |
-|     2      | Interrupts                                                | C1.1         | Planned           |
-|     3      | [8 Bit Operations + Registers](./half-word-operations)    | None         | Under Development |
-|     4      | [Conditional Execution](./conditional-prefix)             | VWI          | Under Development |
-|     5      | [Expanded Registers](./expanded-registers)                | VWI          | Under Development |
-|     6      | Cache Instructions                                        | VWI          | Planned           |
-|     7      | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | C1.1         | Under Development |
-|     13     | [Memory Operands 2](./memory-operands-2) (MO2)            | VWI          | Under Development |
-|     14     | [32 Bit Operations + Registers](./double-word-operations) | None         | Under Development |
-|     15     | [64 Bit Operations + Registers](./quad-word-operations)   | None         | Under Development |
-|     16     | 32 Bit Address Space                                      | C1.14        | Planned           |
-|     17     | Virtual Memory + 32 Bit Paging                            | C1.16, C2.2  | Planned           |
-|     32     | 64 Bit Address Space                                      | C1.15        | Planned           |
-|     33     | Virtual Memory + 64 Bit Paging                            | C1.32, C2.2  | Planned           |
+| CPUID1 bit | Extension                                                 | Dependencies  | State             |
+|:----------:|-----------------------------------------------------------|:-------------:|-------------------|
+|     0      | [Full Immediate](./full-immediates)                       | VWI           | Under Development |
+|     1      | [Stack & Functions](./stack-and-functions)                | None          | Under Development |
+|     2      | Interrupts                                                | CP1.1         | Planned           |
+|     3      | [8 Bit Operations + Registers](./half-word-operations)    | None          | Under Development |
+|     4      | [Conditional Execution](./conditional-prefix)             | VWI           | Under Development |
+|     5      | [Expanded Registers](./expanded-registers)                | VWI           | Under Development |
+|     6      | Cache Instructions                                        | VWI           | Planned           |
+|     7      | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | CP1.1         | Under Development |
+|     13     | [Memory Operands 2](./memory-operands-2) (MO2)            | VWI           | Under Development |
+|     14     | [32 Bit Operations + Registers](./double-word-operations) | None          | Under Development |
+|     15     | [64 Bit Operations + Registers](./quad-word-operations)   | None          | Under Development |
+|     16     | 32 Bit Address Space                                      | CP1.14        | Planned           |
+|     17     | Virtual Memory + 32 Bit Paging                            | CP1.16, CP2.2 | Planned           |
+|     32     | 64 Bit Address Space                                      | CP1.15        | Planned           |
+|     33     | Virtual Memory + 64 Bit Paging                            | CP1.32, CP2.2 | Planned           |
 
 
-| CPUID2 bit | Extension                                                 | Dependencies | State             |
-|:----------:|-----------------------------------------------------------|:------------:|-------------------|
-|     0      | [Expanded Opcodes](./expanded-opcodes)                    | VWI          | Under Development |
-|     1      | [Memory Operands 1](./memory-operands-1) (MO1)            | VWI          | Under Development |
-|     2      | Privileged Mode                                           | C1.2         | Planned           |
-|     3      | Bit Manipulation 1                                        | C2.0         | Planned           |
-|     4      | Bit Manipulation 2                                        | C2.0         | Planned           |
+| CPUID2 bit | Extension                                                 | Dependencies  | State             |
+|:----------:|-----------------------------------------------------------|:-------------:|-------------------|
+|     0      | [Expanded Opcodes](./expanded-opcodes)                    | VWI           | Under Development |
+|     1      | [Memory Operands 1](./memory-operands-1) (MO1)            | VWI           | Under Development |
+|     2      | Privileged Mode                                           | CP1.2         | Planned           |
+|     3      | Bit Manipulation 1                                        | CP2.0         | Planned           |
+|     4      | Bit Manipulation 2                                        | CP2.0         | Planned           |
 
 
 The column Dependencies gives the CPUIDs of the required other extensions (base and recursive requirements are implied). For example, the Interrupts extension, with bit ID 2, depends on "Stack and Functions", with bit ID 1.  Note that only required dependencies are listed. Optional dependencies/interactions with other extensions are not listed here. For example, many extensions will have some interactions with VWI or the byte operations extensions, but those are not visible in the above table.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,25 +1,31 @@
 # Extensions
 
-| CPUID bit | Extension                                                 | Dependencies | State             |
-|:---------:|-----------------------------------------------------------|:------------:|-------------------|
-|     0     | [Full Immediate](./full-immediates)                       | VWI          | Under Development |
-|     1     | [Stack & Functions](./stack-and-functions)                | None         | Under Development |
-|     2     | Interrupts                                                | 1            | Planned           |
-|     3     | [8 Bit Operations + Registers](./half-word-operations)    | None         | Under Development |
-|     4     | [Conditional Execution](./conditional-prefix)             | VWI          | Under Development |
-|     5     | [Expanded Registers](./expanded-registers)                | VWI          | Under Development |
-|     6     | Privileged Mode                                           | 2            | Planned           |
-|     7     | Cache Instructions                                        | VWI          | Planned           |
-|     8     | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | 1            | Under Development |
-|     9     | [Expanded Opcodes](./expanded-opcodes)                    | VWI          | Under Development |
-|     12    | [Memory Operands 1](./memory-operands-1) (MO1)            | VWI          | Under Development |
-|     13    | [Memory Operands 2](./memory-operands-2) (MO2)            | VWI          | Under Development |
-|     14    | [32 Bit Operations + Registers](./double-word-operations) | None         | Under Development |
-|     15    | [64 Bit Operations + Registers](./quad-word-operations)   | None         | Under Development |
-|     16    | 32 Bit Address Space                                      | 14           | Planned           |
-|     17    | Virtual Memory + 32 Bit Paging                            | 6, 16        | Planned           |
-|     32    | 64 Bit Address Space                                      | 15           | Planned           |
-|     33    | Virtual Memory + 64 Bit Paging                            | 6, 32        | Planned           |
+| CPUID1 bit | Extension                                                 | Dependencies | State             |
+|:----------:|-----------------------------------------------------------|:------------:|-------------------|
+|     0      | [Full Immediate](./full-immediates)                       | VWI          | Under Development |
+|     1      | [Stack & Functions](./stack-and-functions)                | None         | Under Development |
+|     2      | Interrupts                                                | C1.1         | Planned           |
+|     3      | [8 Bit Operations + Registers](./half-word-operations)    | None         | Under Development |
+|     4      | [Conditional Execution](./conditional-prefix)             | VWI          | Under Development |
+|     5      | [Expanded Registers](./expanded-registers)                | VWI          | Under Development |
+|     6      | Cache Instructions                                        | VWI          | Planned           |
+|     7      | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | C1.1         | Under Development |
+|     13     | [Memory Operands 2](./memory-operands-2) (MO2)            | VWI          | Under Development |
+|     14     | [32 Bit Operations + Registers](./double-word-operations) | None         | Under Development |
+|     15     | [64 Bit Operations + Registers](./quad-word-operations)   | None         | Under Development |
+|     16     | 32 Bit Address Space                                      | C1.14        | Planned           |
+|     17     | Virtual Memory + 32 Bit Paging                            | C1.16, C2.2  | Planned           |
+|     32     | 64 Bit Address Space                                      | C1.15        | Planned           |
+|     33     | Virtual Memory + 64 Bit Paging                            | C1.32, C2.2  | Planned           |
+
+
+| CPUID2 bit | Extension                                                 | Dependencies | State             |
+|:----------:|-----------------------------------------------------------|:------------:|-------------------|
+|     0      | [Expanded Opcodes](./expanded-opcodes)                    | VWI          | Under Development |
+|     1      | [Memory Operands 1](./memory-operands-1) (MO1)            | VWI          | Under Development |
+|     2      | Privileged Mode                                           | C1.2         | Planned           |
+|     3      | Bit Manipulation 1                                        | C2.0         | Planned           |
+|     4      | Bit Manipulation 2                                        | C2.0         | Planned           |
 
 
 The column Dependencies gives the CPUIDs of the required other extensions (base and recursive requirements are implied). For example, the Interrupts extension, with bit ID 2, depends on "Stack and Functions", with bit ID 1.  Note that only required dependencies are listed. Optional dependencies/interactions with other extensions are not listed here. For example, many extensions will have some interactions with VWI or the byte operations extensions, but those are not visible in the above table.

--- a/extensions/arbitrary-stack-pointer/README.md
+++ b/extensions/arbitrary-stack-pointer/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID Bit: 8**
+**CPUID 1 Bit: 7**
 
 # Overview
 

--- a/extensions/arbitrary-stack-pointer/README.md
+++ b/extensions/arbitrary-stack-pointer/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID1 Bit: 7**
+**CPUID Bit: CP1.7**
 
 # Overview
 

--- a/extensions/arbitrary-stack-pointer/README.md
+++ b/extensions/arbitrary-stack-pointer/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID 1 Bit: 7**
+**CPUID1 Bit: 7**
 
 # Overview
 

--- a/extensions/conditional-prefix/README.md
+++ b/extensions/conditional-prefix/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID Bit: 4**
+**CPUID 1 Bit: 4**
 
 # Overview
 

--- a/extensions/conditional-prefix/README.md
+++ b/extensions/conditional-prefix/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID 1 Bit: 4**
+**CPUID1 Bit: 4**
 
 # Overview
 

--- a/extensions/conditional-prefix/README.md
+++ b/extensions/conditional-prefix/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID1 Bit: 4**
+**CPUID Bit: CP1.4**
 
 # Overview
 

--- a/extensions/double-word-operations/README.md
+++ b/extensions/double-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID1 Bit: 14**
+**CPUID Bit: CP1.14**
 
 - All registers (excluding the `PC`) _must_ be able to store 32 bit (double word) values
 - The SS bits in the calculation opcode can now be set to 10.

--- a/extensions/double-word-operations/README.md
+++ b/extensions/double-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID 1 Bit: 14**
+**CPUID1 Bit: 14**
 
 - All registers (excluding the `PC`) _must_ be able to store 32 bit (double word) values
 - The SS bits in the calculation opcode can now be set to 10.

--- a/extensions/double-word-operations/README.md
+++ b/extensions/double-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID Bit: 14**
+**CPUID 1 Bit: 14**
 
 - All registers (excluding the `PC`) _must_ be able to store 32 bit (double word) values
 - The SS bits in the calculation opcode can now be set to 10.

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID 2 Bit: 0**
+**CPUID2 Bit: 0**
 
 # Overview
 

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID Bit: 9**
+**CPUID 2 Bit: 0**
 
 # Overview
 

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID2 Bit: 0**
+**CPUID Bit: CP2.0**
 
 # Overview
 

--- a/extensions/expanded-registers/README.md
+++ b/extensions/expanded-registers/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID 1 Bit: 5**
+**CPUID1 Bit: 5**
 
 # Overview
 

--- a/extensions/expanded-registers/README.md
+++ b/extensions/expanded-registers/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID1 Bit: 5**
+**CPUID Bit: CP1.5**
 
 # Overview
 

--- a/extensions/expanded-registers/README.md
+++ b/extensions/expanded-registers/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID Bit: 5**
+**CPUID 1 Bit: 5**
 
 # Overview
 

--- a/extensions/full-immediates/README.md
+++ b/extensions/full-immediates/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID 1 Bit: 0**
+**CPUID1 Bit: 0**
 
 # Overview
 

--- a/extensions/full-immediates/README.md
+++ b/extensions/full-immediates/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID Bit: 0**
+**CPUID 1 Bit: 0**
 
 # Overview
 

--- a/extensions/full-immediates/README.md
+++ b/extensions/full-immediates/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID1 Bit: 0**
+**CPUID Bit: CP1.0**
 
 # Overview
 

--- a/extensions/half-word-operations/README.md
+++ b/extensions/half-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID Bit: 3**
+**CPUID 1 Bit: 3**
 
 - The SS bits in the calculation opcode can now be set to 00.
 - When the SS bits are set to 00, the calculation is performed as if the operation was for 8 bit values.

--- a/extensions/half-word-operations/README.md
+++ b/extensions/half-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID 1 Bit: 3**
+**CPUID1 Bit: 3**
 
 - The SS bits in the calculation opcode can now be set to 00.
 - When the SS bits are set to 00, the calculation is performed as if the operation was for 8 bit values.

--- a/extensions/half-word-operations/README.md
+++ b/extensions/half-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID1 Bit: 3**
+**CPUID Bit: CP1.3**
 
 - The SS bits in the calculation opcode can now be set to 00.
 - When the SS bits are set to 00, the calculation is performed as if the operation was for 8 bit values.

--- a/extensions/memory-operands-1/README.md
+++ b/extensions/memory-operands-1/README.md
@@ -1,11 +1,8 @@
 # General design
 
-**Extension State: Under Development**
-
-**Enabled by Default: Yes**
-
-**Requires: Base, VWI**
-
+**Extension State: Under Development**  
+**Enabled by Default: Yes**  
+**Requires: Base, VWI**  
 **CPUID 2 Bit: 1**
 
 # Overview

--- a/extensions/memory-operands-1/README.md
+++ b/extensions/memory-operands-1/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID2 Bit: 1**
+**CPUID Bit: CP2.1**
 
 # Overview
 

--- a/extensions/memory-operands-1/README.md
+++ b/extensions/memory-operands-1/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID 2 Bit: 1**
+**CPUID2 Bit: 1**
 
 # Overview
 

--- a/extensions/memory-operands-1/README.md
+++ b/extensions/memory-operands-1/README.md
@@ -6,7 +6,7 @@
 
 **Requires: Base, VWI**
 
-**CPUID Bit: 12**
+**CPUID 2 Bit: 1**
 
 # Overview
 

--- a/extensions/memory-operands-2/README.md
+++ b/extensions/memory-operands-2/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID1 Bit: 13**
+**CPUID Bit: CP1.13**
 
 # Overview
 

--- a/extensions/memory-operands-2/README.md
+++ b/extensions/memory-operands-2/README.md
@@ -1,11 +1,8 @@
 # General design
 
-**Extension State: Under Development**
-
-**Enabled by Default: Yes**
-
-**Requires: Base, VWI**
-
+**Extension State: Under Development**  
+**Enabled by Default: Yes**  
+**Requires: Base, VWI**  
 **CPUID 1 Bit: 13**
 
 # Overview

--- a/extensions/memory-operands-2/README.md
+++ b/extensions/memory-operands-2/README.md
@@ -6,7 +6,7 @@
 
 **Requires: Base, VWI**
 
-**CPUID Bit: 13**
+**CPUID 1 Bit: 13**
 
 # Overview
 

--- a/extensions/memory-operands-2/README.md
+++ b/extensions/memory-operands-2/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base, VWI**  
-**CPUID 1 Bit: 13**
+**CPUID1 Bit: 13**
 
 # Overview
 

--- a/extensions/quad-word-operations/README.md
+++ b/extensions/quad-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID 1 Bit: 15**
+**CPUID1 Bit: 15**
 
 - All registers (excluding the `PC`) _must_ be able to store 64 bit (quad word) values
 - The SS bits in the calculation opcode can now be set to 11.

--- a/extensions/quad-word-operations/README.md
+++ b/extensions/quad-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID Bit: 15**
+**CPUID 1 Bit: 15**
 
 - All registers (excluding the `PC`) _must_ be able to store 64 bit (quad word) values
 - The SS bits in the calculation opcode can now be set to 11.

--- a/extensions/quad-word-operations/README.md
+++ b/extensions/quad-word-operations/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID1 Bit: 15**
+**CPUID Bit: CP1.15**
 
 - All registers (excluding the `PC`) _must_ be able to store 64 bit (quad word) values
 - The SS bits in the calculation opcode can now be set to 11.

--- a/extensions/stack-and-functions/README.md
+++ b/extensions/stack-and-functions/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID 1 Bit: 1**
+**CPUID1 Bit: 1**
 
 # Overview
 

--- a/extensions/stack-and-functions/README.md
+++ b/extensions/stack-and-functions/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID1 Bit: 1**
+**CPUID Bit: CP1.1**
 
 # Overview
 

--- a/extensions/stack-and-functions/README.md
+++ b/extensions/stack-and-functions/README.md
@@ -3,7 +3,7 @@
 **Extension State: Under Development**  
 **Enabled by Default: Yes**  
 **Requires: Base**  
-**CPUID Bit: 1**
+**CPUID 1 Bit: 1**
 
 # Overview
 

--- a/rationale.md
+++ b/rationale.md
@@ -93,4 +93,4 @@ fail:
           hlt               ; halt and catch fire
 can_work: ... ; rest of the program (including interupt setup)
 ```
-These eight extensions together make up `etca.f.f.0` or the "core extensions".
+These eight extensions together make up `ETCa.F.F.0` or the "core extensions".

--- a/rationale.md
+++ b/rationale.md
@@ -78,7 +78,7 @@ Of course, an extension will indicate that the processor supports executable RAM
 
 ### Placement of Extensions
 
-The selection of which extensions are put into the first 4 bits of `CPUID1` and `CPUID2` is done with the thought that these are commonly (but not always) used and implemented extensions, that if not present are for many programs complete deal-breakers, i.e. they can't work if those are missing. They are assigned to the first 4 bits because those are easy to check for/enable when only base-isa is available, using code similar to this
+The selection of which extensions are put into the first 4 bits of `CPUID1` and `CPUID2` is done with the thought that these are commonly (but not always) used and implemented extensions, that if not present are for many programs complete deal-breakers, i.e. they can't work if those are missing. They are assigned to the first 4 bits because those are easy to check for/enable when only base-isa is available, using code similar to this.
 
 ```asm
           mov  %r0, cpuid1

--- a/rationale.md
+++ b/rationale.md
@@ -78,14 +78,19 @@ Of course, an extension will indicate that the processor supports executable RAM
 
 ### Placement of Extensions
 
-The selection of which extensions are put into the first 4 bits of `CPUID` is done with the thought that these are commonly (but not always) used and implemented extensions, that if not present are for many programs complete deal-breakers, i.e. they can't work if those are missing. They are assigned to the first 4 bits because those are easy to check for/enable when only base-isa is available, using code similar to this
+The selection of which extensions are put into the first 4 bits of `CPUID1` and `CPUID2` is done with the thought that these are commonly (but not always) used and implemented extensions, that if not present are for many programs complete deal-breakers, i.e. they can't work if those are missing. They are assigned to the first 4 bits because those are easy to check for/enable when only base-isa is available, using code similar to this
 
 ```asm
-          mov  %r0, cpudid
+          mov  %r0, cpuid1
+          and  %r0, 0xF
+          cmp  %r0, 0xF     ; are the core extensions available?
+          jne  fail
+          mov  %r0, cpuid2
           and  %r0, 0xF
           cmp  %r0, 0xF     ; are the core extensions available?
           jeq  can_work
+fail:
           hlt               ; halt and catch fire
 can_work: ... ; rest of the program (including interupt setup)
 ```
-These four extensions together make up `ETC.a.F` or the "core extensions".
+These eight extensions together make up `etca.f.f.0` or the "core extensions".


### PR DESCRIPTION
This PR accomplishes a few things:

1. The EXTEN CR is removed since it's not actually used by any currently defined instructions.
    - Only a few planned extensions use it, and at least 2 of those require a partially enabled state in the first place.
    - This CR will be added back in a more useful way by extensions that use it when they are drafted.
2. A second CPUID CR is added.
    - This allows for a more feature rich base for etca
    - This also allows for more extensions that don't require the 32 or 64 bit operation extensions just to check if they're present