### PR TITLE
Clarify expanded opcode jump instructions

### DIFF
--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -60,7 +60,7 @@ This extension adds an expanded instruction format to allow for a larger number 
 | D      | signed displacement                             |
 | I      | unsigned immediate                              |
 
-`SS = 00,01,10,11` means that 1,2,4,8 additional bytes are read as the signed displacement/unsigned immediate. These SS bits are not controlled with the operand size extensions. `SS = 10` is reserved unless the 32 or 64 bit address extensions are enabled. `SS = 11` is reserved unless the 64 bit address extension is enabled.
+`SS = 00,01,10,11` means that 1,2,4,8 bytes are read as the signed displacement/unsigned immediate. These SS bits are not controlled with the operand size extensions. `SS = 10` is reserved unless the 32 or 64 bit address extensions are enabled. `SS = 11` is reserved unless the 64 bit address extension is enabled.
 
 Absolute jumps only overwrite the lower bits of the program counter.
 


### PR DESCRIPTION
Removes the word "additional" to remove confusion about how many bytes are read for the jump instructions.