### PR TITLE
Put carry flag in bit 0

### DIFF
--- a/extensions/interrupts/README.md
+++ b/extensions/interrupts/README.md
@@ -34,9 +34,9 @@ The following table specifies which flag is associated with which bit in the `FL
 
 | Bit | Flag     |
 |-----|----------|
-| 0   | Zero     |
-| 1   | Negative |
-| 2   | Carry    |
+| 0   | Carry    |
+| 1   | Zero     |
+| 2   | Negative |
 | 3   | Overflow |
 
 # Added Interrupts


### PR DESCRIPTION
This makes implementation of ADC, SBC, and RSBC easier by allowing the flags to be directly input to the carry in of the ALU of TC