### PR TITLE
Fixes and additions

### DIFF
--- a/extensions/32-bit-address-space/README.md
+++ b/extensions/32-bit-address-space/README.md
@@ -14,18 +14,18 @@ In particular, this extension focuses on the _Real 32-bit address mode_.
 
 # Modes
 
-CR `1111`, equivalently `cr15` or "the MODE control register," holds a value indicating the current
+CR `1 0001`, equivalently `cr17` or "the MODE control register," holds a value indicating the current
 _mode_ of the processor.
 
 ## Base Mode
 
 The mode described by [the base isa](../../base-isa.md) is known as the
 Base mode. In that mode, pointers are 16 bits and there is no virtual memory, paging, or memory protection.
-Base mode is indicated by a value of 0 in `cr15`.
+Base mode is indicated by a value of 0 in `cr17`.
 
 ## Real 32-bit Address Mode
 
-A new mode known as _Real 32-bit address mode_ is added, indicated by a value of 2 in `cr15`.
+A new mode known as _Real 32-bit address mode_ is added, indicated by a value of 2 in `cr17`.
 In real 32-bit address mode, all addresses are treated as being 32 bit long. Addresses in Base mode refer to the (real) address which is their sign extension to 32 bits.
 
 Entering real 32-bit
@@ -46,7 +46,7 @@ is `doubleword`.
 (The above language is chosen because other values of the MODE register may also specify
 a `doubleword` address mode)
 
-If the system supports [privilege levels](../privileged-mode/), then `cr14` is only writable at the system level.
+If the system supports [privilege levels](../privileged-mode/), then `cr17` is only writable at the system level.
 
 # Recommendations
 

--- a/extensions/32-bit-address-space/README.md
+++ b/extensions/32-bit-address-space/README.md
@@ -14,18 +14,18 @@ In particular, this extension focuses on the _Real 32-bit address mode_.
 
 # Modes
 
-CR `1110`, equivalently `cr14` or "the MODE control register," holds a value indicating the current
+CR `1111`, equivalently `cr15` or "the MODE control register," holds a value indicating the current
 _mode_ of the processor.
 
 ## Base Mode
 
 The mode described by [the base isa](../../base-isa.md) is known as the
 Base mode. In that mode, pointers are 16 bits and there is no virtual memory, paging, or memory protection.
-Base mode is indicated by a value of 0 in `cr14`.
+Base mode is indicated by a value of 0 in `cr15`.
 
 ## Real 32-bit Address Mode
 
-A new mode known as _Real 32-bit address mode_ is added, indicated by a value of 2 in `cr14`.
+A new mode known as _Real 32-bit address mode_ is added, indicated by a value of 2 in `cr15`.
 In real 32-bit address mode, all addresses are treated as being 32 bit long. Addresses in Base mode refer to the (real) address which is their sign extension to 32 bits.
 
 Entering real 32-bit

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -8,7 +8,7 @@
 |     3      | [8 Bit Operations + Registers](./half-word-operations)    | None          | Mostly Stable     |
 |     4      | [Conditional Execution](./conditional-prefix)             | VWI           | Under Development |
 |     5      | [Expanded Registers](./expanded-registers)                | VWI           | Under Development |
-|     6      | [Cache Instructions](./cache-instructions)                | None          | Under Development |
+|     6      | [Cache Instructions](./cache-instructions)                | VWI           | Under Development |
 |     7      | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | CP1.1         | Under Development |
 |     13     | [Memory Operands 2](./memory-operands-2) (MO2)            | VWI           | Under Development |
 |     14     | [32 Bit Operations + Registers](./double-word-operations) | None          | Mostly Stable     |

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -8,7 +8,7 @@
 |     3      | [8 Bit Operations + Registers](./half-word-operations)    | None          | Mostly Stable     |
 |     4      | [Conditional Execution](./conditional-prefix)             | VWI           | Under Development |
 |     5      | [Expanded Registers](./expanded-registers)                | VWI           | Under Development |
-|     6      | [Cache Instructions](./cache-instructions)                | VWI           | Under Development |
+|     6      | [Cache Instructions](./cache-instructions)                | None          | Under Development |
 |     7      | [Arbitrary Stack Pointer](./arbitrary-stack-pointer)      | CP1.1         | Under Development |
 |     13     | [Memory Operands 2](./memory-operands-2) (MO2)            | VWI           | Under Development |
 |     14     | [32 Bit Operations + Registers](./double-word-operations) | None          | Mostly Stable     |

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -39,11 +39,14 @@ If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
 in which case it _may_ be 0.
 
 `NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
-This control register is set to 0 on CPU initialization. When writing to this control register, the value will be sign extended from the current physical address width to the maxiumum supported physical address width. Writing a non-cache-aligned value
-is _unspecified_ behavior.
+This control register is set to 0 on CPU initialization.
 
 `NO_CACHE_END` is a cache-aligned address which represents the inclusive end of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
-This control register is set to -`CACHE_LINE_SIZE` on CPU initialization. When writing to this control register, the value will be sign extended from the current physical address width to the maximum supported physical address width. Writing a
-non-cache-aligned value is _unspecified_ behavior.
+This control register is set to `-CACHE_LINE_SIZE` on CPU initialization.
 
-If `NO_CACHE_START` is larger than `NO_CACHE_END`, the non-cacheable address range wraps past the end of the address space back to the beginning.
+## Notes on `NO_CACHE_START` and `NO_CACHE_END`
+
+- The purpose of the initial values for these control registers is to intially disable caching since the location of MMIO is unknown.
+- When writing to this control register, the value will be sign extended from the current physical address width to the maxiumum supported physical address width.
+- Writing a non-cache-aligned value is _unspecified_ behavior
+- If `NO_CACHE_START` is larger than `NO_CACHE_END`, the non-cacheable address range wraps past the end of the address space back to the beginning.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -47,6 +47,6 @@ This control register is set to `-CACHE_LINE_SIZE` on CPU initialization.
 ## Notes on `NO_CACHE_START` and `NO_CACHE_END`
 
 - The purpose of the initial values for these control registers is to intially disable caching since the location of MMIO is unknown.
-- When writing to this control register, the value will be sign extended from the current physical address width to the maxiumum supported physical address width.
+- When writing to these control registers, the value will be sign extended from the write width to the maxiumum supported physical address width.
 - Writing a non-cache-aligned value is _unspecified_ behavior
 - If `NO_CACHE_START` is larger than `NO_CACHE_END`, the non-cacheable address range wraps past the end of the address space back to the beginning.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -39,7 +39,11 @@ If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
 in which case it _may_ be 0.
 
 `NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
-This control register is set to 0 on CPU initialization.
+This control register is set to 0 on CPU initialization. When writing to this control register, the value will be sign extended from the current physical address width to the maxiumum supported physical address width. Writing a non-cache-aligned value
+is _unspecified_ behavior.
 
 `NO_CACHE_END` is a cache-aligned address which represents the inclusive end of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
-This control register is set to -`CACHE_LINE_SIZE` on CPU initialization.
+This control register is set to -`CACHE_LINE_SIZE` on CPU initialization. When writing to this control register, the value will be sign extended from the current physical address width to the maximum supported physical address width. Writing a
+non-cache-aligned value is _unspecified_ behavior.
+
+If `NO_CACHE_START` is larger than `NO_CACHE_END`, the non-cacheable address range wraps past the end of the address space back to the beginning.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -29,17 +29,23 @@ If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
 
 # Added Instruction Prefixes
 
-| Name       | Byte        | Description                                                                                     |
-|------------|-------------|-------------------------------------------------------------------------------------------------|
-| `NO_CACHE` | `1101 0000` | This prefix causes the following instruction to bypass the data cache for its memory access(es) |
+| Name           | Byte        | Description                                                                                     |
+|----------------|-------------|-------------------------------------------------------------------------------------------------|
+| `BYPASS_CACHE` | `1101 0000` | This prefix causes the following instruction to bypass the data cache for its memory access(es) |
 
 If this prefix is used with an instruction that does not access memory or there is no data cache, the prefix does nothing.
 
 # Added Control Registers
 
-| CRN    | Name              |
-|--------|-------------------|
-| `1110` | `CACHE_LINE_SIZE` |
+| CRN    | Name               |
+|--------|---------------------|
+| `0 1110` | `CACHE_LINE_SIZE` |
+| `0 1111` | `NO_CACHE_START`  |
+| `1 0000` | `NO_CACHE_END`    |
 
 `CACHE_LINE_SIZE` is a read-only control register which specifies the number of bytes in a cache line for the data cache. It _must_ be a power of 2 unless no data cache is present
 in which case it _may_ be 0.
+
+`NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
+
+`NO_CACHE_END` is a cache-aligned address which represents the exclusive end of a contiguous range of memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -1,7 +1,7 @@
 # General design
 
 **Extension State: Under Development**  
-**Requires: Base**  
+**Requires: VWI**  
 **CPUID Bit: CP1.6**
 
 # Overview
@@ -26,6 +26,14 @@ Note that the last 5 instructions overlap with the never jump instruction. This 
 
 If this extension is present on a system without a data cache, `ALLOC_ZERO` must write 0 to memory as if it had a cache line size as specified by the `CACHE_LINE_SIZE` control register.
 If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
+
+# Added Instruction Prefixes
+
+| Name       | Byte        | Description                                                                                     |
+|------------|-------------|-------------------------------------------------------------------------------------------------|
+| `NO_CACHE` | `1101 0000` | This prefix causes the following instruction to bypass the data cache for its memory access(es) |
+
+If this prefix is used with an instruction that does not access memory or there is no data cache, the prefix does nothing.
 
 # Added Control Registers
 

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -1,7 +1,7 @@
 # General design
 
 **Extension State: Under Development**  
-**Requires: VWI**  
+**Requires: Base**  
 **CPUID Bit: CP1.6**
 
 # Overview
@@ -27,18 +27,10 @@ Note that the last 5 instructions overlap with the never jump instruction. This 
 If this extension is present on a system without a data cache, `ALLOC_ZERO` must write 0 to memory as if it had a cache line size as specified by the `CACHE_LINE_SIZE` control register.
 If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
 
-# Added Instruction Prefixes
-
-| Name           | Byte        | Description                                                                                     |
-|----------------|-------------|-------------------------------------------------------------------------------------------------|
-| `BYPASS_CACHE` | `1101 0000` | This prefix causes the following instruction to bypass the data cache for its memory access(es) |
-
-If this prefix is used with an instruction that does not access memory or there is no data cache, the prefix does nothing.
-
 # Added Control Registers
 
-| CRN    | Name               |
-|--------|---------------------|
+| CRN      | Name               |
+|----------|---------------------|
 | `0 1110` | `CACHE_LINE_SIZE` |
 | `0 1111` | `NO_CACHE_START`  |
 | `1 0000` | `NO_CACHE_END`    |
@@ -46,8 +38,8 @@ If this prefix is used with an instruction that does not access memory or there 
 `CACHE_LINE_SIZE` is a read-only control register which specifies the number of bytes in a cache line for the data cache. It _must_ be a power of 2 unless no data cache is present
 in which case it _may_ be 0.
 
-`NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
+`NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
 This control register is set to 0 on CPU initialization.
 
-`NO_CACHE_END` is a cache-aligned address which represents the exclusive end of a contiguous range of memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
-This control register is set to the same value as `CACHE_LINE_SIZE` on CPU initialization.
+`NO_CACHE_END` is a cache-aligned address which represents the inclusive end of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
+This control register is set to -`CACHE_LINE_SIZE` on CPU initialization.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -47,5 +47,7 @@ If this prefix is used with an instruction that does not access memory or there 
 in which case it _may_ be 0.
 
 `NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
+This control register is set to 0 on CPU initialization.
 
 `NO_CACHE_END` is a cache-aligned address which represents the exclusive end of a contiguous range of memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
+This control register is set to the same value as `CACHE_LINE_SIZE` on CPU initialization.

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -29,9 +29,5 @@ Unless specified otherwise, each prefix can only be used _at most_ once per inst
 |:------------|:--------------------------------------------------------------|
 | `1010 xxxx` | When `xxxx` is neither `1110` nor `1111`, conditional prefix. |
 | `1100 xxxx` | Expanded registers prefix and large immediate bit.            |
-| `1101 0000` | Bypasses the data cache for memory operations.                |
-| `1101 0001` | Unused                                                        |
-| `1101 001x` | Unused                                                        |
-| `1101 01xx` | Unused                                                        |
-| `1101 1xxx` | Unused                                                        |
+| `1101 xxxx` | Unused                                                        |
 

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -25,9 +25,13 @@ Unless specified otherwise, each prefix can only be used _at most_ once per inst
 
 ### Defined Prefix Sequences
 
-| Prefix      | Description                                                  |
-|:------------|:-------------------------------------------------------------|
-| `1010 xxxx` | When `xxxx` is neither `1110` nor `1111`, conditional prefix |
-| `1100 xxxx` | Expanded registers prefix and large immediate bit            |
-| `1101 xxxx` | Unused                                                       |
+| Prefix      | Description                                                   |
+|:------------|:--------------------------------------------------------------|
+| `1010 xxxx` | When `xxxx` is neither `1110` nor `1111`, conditional prefix. |
+| `1100 xxxx` | Expanded registers prefix and large immediate bit.            |
+| `1101 0000` | Bypasses the data cache for memory operations.                |
+| `1101 0001` | Unused                                                        |
+| `1101 001x` | Unused                                                        |
+| `1101 01xx` | Unused                                                        |
+| `1101 1xxx` | Unused                                                        |
 


### PR DESCRIPTION
- Change the addressing mode control register to 17 because 14 was already taken by the cache line size control register and the 2 added cache line control registers should be contiguous with the first.
- Add 2 control registers to the cache instruction extension to allow for specifying a region of memory which should not be cached. Useful for system to mark where IO is located in memory.
- Add a bypass cache prefix to the cache instructions extension since that may be required by a system ROM to properly initialize. I'm not sure if this is actually needed since since the `NO_CACHE` control registers default to setting the first cache line as non-cacheable memory.