### PR TITLE
Interrupt Rework 2: Electric Boogaloo

### DIFF
--- a/extensions/32-bit-address-space/README.md
+++ b/extensions/32-bit-address-space/README.md
@@ -10,6 +10,6 @@ This extension adds a 32-bit addressing mode to the ISA. In particular, this ext
 
 ## Real 32-bit Address Mode
 
-A new mode known as _Real 32-bit address mode_ is added, indicated by a value of 2 in `cr17`.
+A new mode known as _Real 32-bit address mode_ is added, indicated by a value of 2 in `cr15`.
 
 Refer to the [Mode Control Register](../mode-control-register.md#real-n-bit-address-mode) documentation for how real 32-bit addresses behave in relation to other modes.

--- a/extensions/64-bit-address-space/README.md
+++ b/extensions/64-bit-address-space/README.md
@@ -10,6 +10,6 @@ This extension adds a 64-bit addressing mode to the ISA. In particular, this ext
 
 ## Real 64-bit Address Mode
 
-A new mode known as _Real 64-bit address mode_ is added, indicated by a value of 4 in `cr17`.
+A new mode known as _Real 64-bit address mode_ is added, indicated by a value of 4 in `cr15`.
 
 Refer to the [Mode Control Register](../mode-control-register.md#real-n-bit-address-mode) documentation for how real 64-bit addresses behave in relation to other modes.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -32,11 +32,11 @@ If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
 
 # Added Control Registers
 
-| CRN      | Name               |
-|----------|---------------------|
-| `0 1110` | `CACHE_LINE_SIZE` |
-| `0 1111` | `NO_CACHE_START`  |
-| `1 0000` | `NO_CACHE_END`    |
+| CRN    | Name               |
+|--------|---------------------|
+| `1100` | `CACHE_LINE_SIZE` |
+| `1101` | `NO_CACHE_START`  |
+| `1110` | `NO_CACHE_END`    |
 
 `CACHE_LINE_SIZE` is a read-only control register which specifies the number of bytes in a cache line for the data cache. It _must_ be a power of 2 unless no data cache is present
 in which case it _may_ be 0.

--- a/extensions/interrupts/README.md
+++ b/extensions/interrupts/README.md
@@ -59,7 +59,7 @@ The following opcodes are now defined. The bits which are normally reserved for 
 
 | Name      | First Byte    | Second Byte  | Description                                                                                                                    |
 |:----------|:--------------|:-------------|:-------------------------------------------------------------------------------------------------------------------------------|
-| `SYSCALL` | `00 00 1111`  | `000 100 01` | Causes a system call interrupt.                                                                                                |
+| `SYSCALL` | `00 00 1111`  | `000 100 01` | Causes a system call interrupt to occur immediately after this instruction is executed.                                        |
 | `ERET`    | `00 01 1111`  | `000 100 01` | Returns from the current exception handler. Executing this when not in an exception handler causes a General Protection Fault. |
 
 The operating system or kernel ABI must specify how to pass service numbers and service arguments when using `syscall`. Our expectation is that they be passed in general-purpose registers specified by the ABI, but we set no requirements.

--- a/extensions/interrupts/README.md
+++ b/extensions/interrupts/README.md
@@ -11,27 +11,22 @@ This extension adds interrupts which allows for the separation of system managem
 
 # Added Control Registers
 
-| CRN    | Name          | Description                                                                                       | Comment |
-|:-------|:--------------|:--------------------------------------------------------------------------------------------------|:--------|
-| `0011` | `FLAGS`       | Stores the ALU flags and allows them to be set to specific values.                                |         |
-| `0100` | `INT_PC`      | Specifies where the system interrupt handler is located in memory.                                |         |
-| `0101` | `INT_RET_PC`  | Stores the address that the system interrupt should return to.                                    |         |
-| `0110` | `INT_MASK`    | Specifies the mask for system interrupts.                                                         | (1)     |
-| `0111` | `INT_PENDING` | Records which system interrupts are pending.                                                      | (1) (3) |
-| `1000` | `INT_CAUSE`   | Stores the cause of the current system interrupt.                                                 | (2) (3) |
-| `1001` | `INT_DATA`    | Stores data relevant to the interrupt.                                                            | (3)     |
-| `1010` | `INT_SCRATCH_0` | A scratch register available for privileged use.                                     | (4)     |
-| `1011` | `INT_SCRATCH_1` | A second scratch register available privileged use. | (4)     |
-
-When the CPU is first initialized, `INT_MASK` should be set to 0.
+| CRN    | Name            | Description                                                                                       | Comment |
+|:-------|:----------------|:--------------------------------------------------------------------------------------------------|:--------|
+| `0011` | `FLAGS`         | Stores the ALU flags and allows them to be set to specific values.                                |         |
+| `0100` | `INT_PC`        | Specifies where the system interrupt handler is located in memory.                                |         |
+| `0101` | `INT_RET_PC`    | Stores the address that the system interrupt should return to.                                    |         |
+| `0110` | `INT_CAUSE`     | Stores the cause of the current system interrupt.                                                 | (1) (2) |
+| `0111` | `INT_DATA`      | Stores data relevant to the interrupt.                                                            | (2)     |
+| `1000` | `INT_SCRATCH_0` | A scratch register available for privileged use.                                                  | (3)     |
+| `1001` | `INT_SCRATCH_1` | A second scratch register available privileged use.                                               | (3)     |
 
 As a reminder, if [Privileged Mode](../privileged-mode/README.md) is supported, control registers whose names begin with `INT_` are only accessible in system mode. Attempts to access them in user mode
 must trigger a #GP fault.
 
-1) This is a bitfield where each bit corresponds to a specific interrupt based on the table below.
-2) This stores the number which refers to the current interrupt. It's value is the bit number in the mask and pending control registers.
-3) These control registers are not writable through the `writecr` instruction and are effectively read-only. Writing to them is a NOP.
-4) The intent of these registers is to provide a space to save general-purpose registers at the start of an interrupt handler to get the scratch (general-purpose) registers necessary to set up a stack. This is necessary on systems not supporting [FI](../full-immediates/README.md) nor [MO1](../memory-operands-1/README.md). Regardless, they are available for any (privileged) purpose.
+1) This stores the number which refers to the current interrupt.
+2) These control registers are not writable through the `writecr` instruction and are effectively read-only. Writing to them is a NOP.
+3) The intent of these registers is to provide a space to save general-purpose registers at the start of an interrupt handler to get the scratch (general-purpose) registers necessary to set up a stack. This is necessary on systems not supporting [FI](../full-immediates/README.md) nor [MO1](../memory-operands-1/README.md). Regardless, they are available for any (privileged) purpose.
 
 ## Flags CR
 
@@ -46,28 +41,25 @@ The following table specifies which flag is associated with which bit in the `FL
 
 # Added Interrupts
 
-| Name                     | Type         | Mask/Pending Bit | Description                                                                                                        |
+| Name                     | Type         | Interrupt Number | Description                                                                                                        |
 |:-------------------------|:-------------|:-----------------|:-------------------------------------------------------------------------------------------------------------------|
-| System Call              | Synchronous  | 0                | Used by programs to ask the operating system to do something.                                                      |
-| Timer                    | Asynchronous | 1                | Occurs when a timer causes an interrupt.                                                                           |
+| External Interrupt       | Asynchronous | 0                | Occurs when an external interrupt occurs (eg. timer, keyboard, mouse, etc.).                                       |
+| System Call              | Synchronous  | 1                | Used by programs to ask the operating system to do something.                                                      |
 | Illegal Instruction      | Synchronous  | 2                | Occurs when execution of a reserved, or illegal instruction is attempted.                                          |
 | Memory Alignment Error   | Synchronous  | 3                | Occurs when an attempt to read or write to memory at an unaligned address occurs and is not supported.             |
 | General Protection Fault | Synchronous  | 4                | Occurs when the CPU needs the operating system to handle an unexpected event for stability or consistency reasons. |
 | Divide Error             | Synchronous  | 5                | Occurs when a division by zero is attempted.                                                                       |
-| External Interrupt       | Asynchronous | 8                | Occurs when an external interrupt occurs (eg. keyboard, mouse, etc.).                                              |
 
 Synchronous interrupts are interrupts which are triggered directly by the currently running code and must be handled immediately before normal execution can resume.  
 Asynchronous interrupts are interrupts which are triggered by another piece of hardware or indirectly from code and do not need to be handled immediately.
-
-Unused mask/pending bits are reserved for future extensions. External interrupt is at bit 8 to leave a bit of space for other internal exceptions.
 
 # Added Instructions
 
 The following opcodes are now defined. The bits which are normally reserved for specifying operation/operand size are repurposed here.
 
-| Name   | First Byte    | Second Byte  | Description                                                                                                                                                                                                                                |
-|:-------|:--------------|:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `SYSCALL` | `00 00 1111`  | `000 100 01` | Causes a system call interrupt.                                                                                |
+| Name      | First Byte    | Second Byte  | Description                                                                                                                    |
+|:----------|:--------------|:-------------|:-------------------------------------------------------------------------------------------------------------------------------|
+| `SYSCALL` | `00 00 1111`  | `000 100 01` | Causes a system call interrupt.                                                                                                |
 | `ERET`    | `00 01 1111`  | `000 100 01` | Returns from the current exception handler. Executing this when not in an exception handler causes a General Protection Fault. |
 
 The operating system or kernel ABI must specify how to pass service numbers and service arguments when using `syscall`. Our expectation is that they be passed in general-purpose registers specified by the ABI, but we set no requirements.
@@ -80,21 +72,19 @@ CPU interrupts from external hardware are rising edge triggered.
 
 If a synchronous interrupt occurs while the CPU is already handling another interrupt, the CPU _must_ reset or halt execution as there is no way for it to handle the interrupt. If the CPU is not handling an interrupt
 when a synchronous exception occurs, the system state is _restored_ to just before the execution of the current instruction began (transparent state such as caches need not be restored).
-Then, the corresponding bit in the `INT_PENDING` CR will be set and the CPU will immediately transition to handling that exception.
+Then, the CPU will immediately transition to handling that exception.
 This means that the CPU _must_ be in the same effective state as before execution of the instruction was attempted aside from changes specified below. One of the
-implied effects of this is that the `INT_RET_PC` CR points to the instruction which caused the interrupt. Another implied effect is that synchronous interrupts _cannot_ be masked.
+implied effects of this is that the `INT_RET_PC` CR points to the instruction which caused the interrupt.
 
-When an asynchronous interrupt occurs, the relevant bit in the pending interrupt CR will be set. If the CPU is not handling an interrupt and any bit in the result of ANDing the `INT_PENDING` CR with the `INT_MASK` CR
-is set, the interrupt for the lowest set bit of that result will be handled. This _must not_ be checked
-during the execution of an instruction; that is, interrupt handling can only begin between instructions.
-This _should_ be checked as soon as possible, however, exact timing is system dependent. Systems are permitted to wait to allow them to ensure progress during interrupt storms, or for microarchitectural reasons.
+When an asynchronous interrupt occurs, the CPU will handle the interrupt at some point when the CPU is not already handling an interrupt **AND** is in between instructions. The interrupt _should_ be handled as soon as
+possible, however, exact timing is system dependent. Systems are permitted to wait to allow them to ensure progress during interrupt storms or for microarchitectural reasons.
 
 In order to handle an interrupt, the CPU _must_ do the following.
 
-1. Set the `INT_CAUSE` CR to the bit index of the interrupt to be handled based on the table above.
+1. Set the `INT_CAUSE` CR to the interrupt number of the interrupt to be handled based on the table above.
 2. Set the `INT_DATA` CR based on the following:
-    - If the cause is a memory alignment error, use the address that caused the error.
     - If the cause is an external interrupt, and some (system-dependent) value can be used to identify the device which caused the interrupt (possibly externally supplied), that value is used.
+    - If the cause is a memory alignment error, use the address that caused the error.
     - Otherwise the value is _unspecified_.
 3. Set the `INT_RET_PC` CR to the current `PC` register.
 4. Set the `PC` register to the value in the `INT_PC` CR.

--- a/extensions/mode-control-register.md
+++ b/extensions/mode-control-register.md
@@ -7,14 +7,14 @@ processor is actually in will almost certainly behave incorrectly.
 
 # Modes
 
-CR `1 0001`, equivalently `cr17` or "the MODE control register," holds a value indicating the current
+CR `1111`, equivalently `cr15` or "the MODE control register," holds a value indicating the current
 _mode_ of the processor. This has an initial value of `0`.
 
 ## Base Mode (Real 16-bit Address Mode)
 
 The mode described by [the base isa](../../base-isa.md) is known as the
 Base mode. In that mode, pointers are 16 bits and there is no virtual memory, paging, or memory protection.
-Base mode is indicated by a value of 0 in `cr17`.
+Base mode is indicated by a value of 0 in `cr15`.
 
 ## Real n-bit Address Mode
 
@@ -42,7 +42,7 @@ should mean or how many bytes an immediate should be.
 | 32 bit       | doubleword   |
 | 64 bit       | quadword     |
 
-If the system supports [privilege levels](../privileged-mode/), then `cr17` is only writable when in system privilege mode.
+If the system supports [privilege levels](../privileged-mode/), then `cr15` is only writable when in system privilege mode.
 
 # Recommendations
 

--- a/extensions/privileged-mode/README.md
+++ b/extensions/privileged-mode/README.md
@@ -15,8 +15,8 @@ While this extension by itself doesn't do much, it's a pre-requisite for more ad
 
 | CRN    | Name           | Description                                                                                |
 |:-------|:---------------|:-------------------------------------------------------------------------------------------|
-| `1100` | `PRIV`         | Specifies the current privilege mode the CPU is running in.                                |
-| `1101` | `INT_RET_PRIV` | Stores the privilege mode that the system should return to after the interrupt is handled. |
+| `1010` | `PRIV`         | Specifies the current privilege mode the CPU is running in.                                |
+| `1011` | `INT_RET_PRIV` | Stores the privilege mode that the system should return to after the interrupt is handled. |
 
 # Added Privilege Modes
 


### PR DESCRIPTION
Based on our conversation in discord, this PR does the following:
1) merges the external and timer interrupt
2) removes the `INT_PENDING` and `INT_MASK` CRs

This makes it so that the CPU handles all synchronous exceptions on it's own and relies on a PIC for all external interrupts. This implies that the PIC is controlled through MMIO and starts off in a disabled state.