### PR TITLE
Draft BM1 extension and move rotate with carry into it

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -22,16 +22,17 @@
 |     35     | Virtual Memory + 64 Bit Paging (64 bit VA)                | PG64 | CP1.32, CP2.2 | Planned           |
 
 
-| CPUID2 bit | Extension                                | Abbr | Dependencies  | State             |
-|:----------:|------------------------------------------|------|:-------------:|-------------------|
-|     0      | [Expanded Opcodes](./expanded-opcodes)   | EXOP |      VWI      | Under Development |
-|     1      | [Memory Operands 1](./memory-operands-1) | MO1  |      VWI      | Under Development |
-|     2      | [Privileged Mode](./privileged-mode)     | PM   |     CP1.2     | Under Development |
-|     3      | [Multiply Divide](./multiply-divide)     | MD   |     CP2.0     | Under Development |
-|     4      | Bit Manipulation 1                       | BM1  |     CP2.0     | Planned           |
-|    8-15    | Reserved for vendor specific extensions  |      |               | Stable            |
-|   24-31    | Reserved for vendor specific extensions  |      |               | Stable            |
-|   48-63    | Reserved for vendor specific extensions  |      |               | Stable            |
+| CPUID2 bit | Extension                                  | Abbr | Dependencies  | State             |
+|:----------:|--------------------------------------------|------|:-------------:|-------------------|
+|     0      | [Expanded Opcodes](./expanded-opcodes)     | EXOP |      VWI      | Under Development |
+|     1      | [Memory Operands 1](./memory-operands-1)   | MO1  |      VWI      | Under Development |
+|     2      | [Privileged Mode](./privileged-mode)       | PM   |     CP1.2     | Under Development |
+|     3      | [Multiply Divide](./multiply-divide)       | MD   |     CP2.0     | Under Development |
+|     4      | [Bit Manipulation 1](./bit-manipulation-1) | BM1  |     CP2.0     | Under Development |
+|     5      | Bit Manipulation 2                         | BM2  |     CP2.0     | Planned           |
+|    8-15    | Reserved for vendor specific extensions    |      |               | Stable            |
+|   24-31    | Reserved for vendor specific extensions    |      |               | Stable            |
+|   48-63    | Reserved for vendor specific extensions    |      |               | Stable            |
 
 
 The column `Dependencies` gives the CPUIDs of the required other extensions (base and recursive requirements are implied). For example, the Interrupts extension, with bit ID 2, depends on "Stack and Functions", with bit ID 1.  Note that only required dependencies are listed. Optional dependencies/interactions with other extensions are not listed here. For example, many extensions will have some interactions with VWI or the byte operations extensions, but those are not visible in the above table.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -26,8 +26,8 @@ These instructions are in the expanded calculation opcode section of instruction
 | `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38 B</code>                             | `ZN`  |             |
 | `0 0001 1000` | `LSB`     | <code>A ← B &#38 -B</code>                             | `ZN`  |             |
 | `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZN`  |             |
-| `0 0001 1010` | `RLSB`    | <code>A ← B &#38 (B - 1)</code>                        | `ZN`  |             |
-| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38 ((1 << B) - 1)</code>                 | `ZN`  |             |
+| `0 0001 1010` | `RLSB`    | <code>A ← B ;&#38 (B - 1)</code>                       | `ZN`  |             |
+| `0 0001 1011` | `ZHIB`    | <code>A ← A ;&#38 ((1 << B) - 1)</code>                | `ZN`  |             |
 
 1) C in the operation column refers to the carry flag.
 2) Only the `M` least significant bits of `B` (or `-B` where applicable) are used for a shift amount.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -59,7 +59,7 @@ int64_t grev(int64_t a, int b, int ss)
 ```
 
 - Byte swap can be formulated in terms of GREV where B=24 (for `SS = 10`).
-- Bit Reverse can be formulated in terms of GREV where B=31 (for `SS = 11`).
+- Bit Reverse can be formulated in terms of GREV where B=31 (for `SS = 10`).
 
 6) Counts the number of `0` bits before the first `1` bit
 7) Counts the number of `0` bits after the last `1` bit

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -27,7 +27,7 @@ These instructions are in the expanded calculation opcode section of instruction
 | `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZN`  | (9)         |
 | `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZNC` | (6) (10)    |
 | `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZNC` | (6) (11)    |
-| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  | (12)        |
+| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B[7:0]) - 1)</code>           | `ZNC` | (12)        |
 
 1) C in the operation column refers to the carry flag.
 2) The `-1` in the operation equivalently indicates a shift amount of one less than the operation size.
@@ -70,14 +70,16 @@ int64_t grev(int64_t a, int b, int ss)
         grev   A,-1
         clz    A,A
 ```
-9) Notes 9, 10, 11, and 12 give examples of the remaining operations; however the behavior
+9) Notes 9, 10, and 11 give examples of the remaining operations; however the behavior
     of these operations is fully specified in the table and comment (6).
    `lsb` isolates the least significant `1` bit of `B`. For example, `lsbx r0, 0xFFA0`
     will result in `0x0020` in `rx0`.
-11) Get a mask of all bits up to and including the least significant `1` bit of `B`.
+10) Get a mask of all bits up to and including the least significant `1` bit of `B`.
     If there is no such bit, the mask is `-1`. For example, `lsmskx r0, 0xFFA0`
     will result in `0x003F` in `rx0`.
-12) Reset (set to `0`) the least significant `1` bit of `B`. For example,
+11) Reset (set to `0`) the least significant `1` bit of `B`. For example,
     `rlsbx r0, 0xFFA0` will result in `0xFF80` in `rx0`.
-13) Zero out the bits of `A` at higher bit indices at least `B`. For example,
-    if `0xABCD` is in `rx0`, then `zhibx r0, 7` results in `0x004D` in `rx0`.
+12) Zero out the bits of `A` at bit indices which are at least `B`. Only the bottom byte
+    of `B` is considered. If `B` exceeds the operation width minus 1, then `A` is unchanged
+    and the `C` flag is set.
+    For example, if `0xABCD` is in `rx0`, then `zhibx r0, 7` results in `0x004D` in `rx0`.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -16,8 +16,8 @@ These instructions are in the expanded calculation opcode section of instruction
 
 | `C CCCC CCCC` | NAME      | Operation                                              | Flags | Comment     |
 |---------------|-----------|--------------------------------------------------------|-------|-------------|
-| `0 0000 1000` | `RCL`     | <code>C:A ← (C:B << 1) &#124; (C:B >> -1)</code>       | `ZNC` | (1) (2) (3) |
-| `0 0000 1001` | `RCR`     | <code>A:C ← (B:C >> 1) &#124; (B:C << -1)</code>       | `ZNC` | (1) (2) (3) |
+| `0 0000 1000` | `RCL`     | <code>C:A ← (C:B << 1) &#124; C</code>                 | `ZNC` | (1) (2) (3) |
+| `0 0000 1001` | `RCR`     | <code>A:C ← (B:C >> 1) &#124; (C << -1)</code>         | `ZNC` | (1) (2) (3) |
 | `0 0000 1010` | `POPCNT`  | <code>A ← POPCNT(B)</code>                             | `Z`   | (4)         |
 | `0 0000 1011` | `GREV`    | <code>A ← GREV(A, B)</code>                            | `ZN`  | (5)         |
 | `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZC`  | (6) (7)     |

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -24,6 +24,10 @@ These instructions are in the expanded calculation opcode section of instruction
 | `0 0000 1101` | `CLZ`     | Counts the number of `0` bits after the last `1` bit   | `ZN`  |             |
 | `0 0000 1110` | `NOT`     | <code>A ← ~B</code>                                    | `ZN`  |             |
 | `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38 B</code>                             | `ZN`  |             |
+| `0 0001 1000` | `LSB`     | <code>A ← B &#38 -B</code>                             | `ZN`  |             |
+| `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZN`  |             |
+| `0 0001 1010` | `RLSB`    | <code>A ← B &#38 (B - 1)</code>                        | `ZN`  |             |
+| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38 ((1 << B) - 1)</code>                 | `ZN`  |             |
 
 1) C in the operation column refers to the carry flag.
 2) Only the `M` least significant bits of `B` (or `-B` where applicable) are used for a shift amount.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -18,15 +18,15 @@ These instructions are in the expanded calculation opcode section of instruction
 |---------------|-----------|--------------------------------------------------------|-------|-------------|
 | `0 0000 1000` | `RCL`     | <code>C:A ← (C:A << B) &#124; (C:A >> -B)</code>       | `ZNC` | (1) (2) (3) |
 | `0 0000 1001` | `RCR`     | <code>A:C ← (A:C >> B) &#124; (A:C << -B)</code>       | `ZNC` | (1) (2) (3) |
-| `0 0000 1010` | `POPCNT`  | <code>A ← POPCNT(B)</code>                             | `ZN`  | (4)         |
+| `0 0000 1010` | `POPCNT`  | <code>A ← POPCNT(B)</code>                             | `Z`   | (4)         |
 | `0 0000 1011` | `GREV`    | <code>A ← GREV(A, B)</code>                            | `ZN`  | (5)         |
-| `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZN`  | (6)         |
-| `0 0000 1101` | `CLZ`     | <code>A ← CLZ(B)</code>                                | `ZN`  | (7)         |
+| `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZC`  | (6)         |
+| `0 0000 1101` | `CLZ`     | <code>A ← CLZ(B)</code>                                | `ZC`  | (7)         |
 | `0 0000 1110` | `NOT`     | <code>A ← ~B</code>                                    | `ZN`  |             |
 | `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38; B</code>                            | `ZN`  |             |
-| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZN`  |             |
-| `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZN`  |             |
-| `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZN`  |             |
+| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZNC` |             |
+| `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZNC` |             |
+| `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZNC` |             |
 | `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  |             |
 
 1) C in the operation column refers to the carry flag.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -16,8 +16,8 @@ These instructions are in the expanded calculation opcode section of instruction
 
 | `C CCCC CCCC` | NAME      | Operation                                              | Flags | Comment     |
 |---------------|-----------|--------------------------------------------------------|-------|-------------|
-| `0 0000 1000` | `RCL`     | <code>C:A ← (C:B << 1) &#124; C</code>                 | `ZNC` | (1) (2) (3) |
-| `0 0000 1001` | `RCR`     | <code>A:C ← (B:C >> 1) &#124; (C << -1)</code>         | `ZNC` | (1) (2) (3) |
+| `0 0000 1000` | `RCL`     | <code>A ← (B << 1) &#124; C</code>                     | `ZNC` | (1) (2) (3) |
+| `0 0000 1001` | `RCR`     | <code>A ← (B >> 1) &#124; (C << -1)</code>             | `ZNC` | (1) (2) (3) |
 | `0 0000 1010` | `POPCNT`  | <code>A ← POPCNT(B)</code>                             | `Z`   | (4)         |
 | `0 0000 1011` | `GREV`    | <code>A ← GREV(A, B)</code>                            | `ZN`  | (5)         |
 | `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZC`  | (6) (7)     |
@@ -33,11 +33,10 @@ These instructions are in the expanded calculation opcode section of instruction
 2) The `-1` in the operation equivalently indicates a shift amount of one less than the operation size.
    `rcl A, B` is nearly equivalent to `adc B, B`, except that the result is stored in operand `A`
    and the `V` flag is undefined after the operation.
-3) The notation C:A represents combining the carry flag with the value in register `A`. If the operation
-    size is `half`, the value is `C AAAA AAAA`, a 9-bit value. The `RCL` instruction rotates this 9-bit
-    value left. The `RCR` instruction rotates the value `AAAA AAAA C` to the right. Therefore, for
-    `rcl`, the `C` flag will be set to the most significant bit of the input, and for `rcl` it will be
-    set to the least significant bit of the input.
+3) The `C` flag is set to the value of the bit shifted out of `B`. Conceptually, these operations perform
+   rotations of the `B` operand extended with the `C` flag as an extra bit. For example, `rcrh r0, 0x02`
+   will result in `0x01` in `rh0` if `C` was clear before, and `0x81` if `C` was not. In both cases, the output `C`
+   will be clear because a `0` was shifted out of `0x02`.
    The operation is analogous for other operation sizes.
 5) Counts the number of set bits in `B` as if it were zero extended based on the `SS` bits.
 6) Performs the generalized swap operation on `A` based on the value in `B`. It acts as follows

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -42,7 +42,7 @@ These instructions are in the expanded calculation opcode section of instruction
     size is `half`, the value is `C AAAA AAAA`, a 9-bit value. The `RCL` instruction rotates this 9-bit
     value left. The `RCR` instruction rotates the value `AAAA AAAA C` to the right. The operation
     is analogous for other operation sizes.
-4) Counts the number of set bits in `B` as if it was zero extended based on the `SS` bits.
+4) Counts the number of set bits in `B` as if it were zero extended based on the `SS` bits.
 5) Performs the generalized swap operation on `A` based on the value in `B`. It acts as follows
 ```
 int64_t grev(int64_t a, int b, int ss)

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -1,0 +1,44 @@
+# General design
+
+**Extension State: Under Development**  
+**Requires: Base, VWI, CP2.0**  
+**CPUID Bit: CP2.4**
+
+# Overview
+
+This extension adds rotate with carry and various bit operations.
+
+# Added Instructions
+
+These instructions are in the expanded calculation opcode section of instructions.
+
+### Opcode table
+
+| `C CCCC CCCC` | NAME      | Operation                                              | Flags | Comment     |
+|---------------|-----------|--------------------------------------------------------|-------|-------------|
+| `0 0000 1000` | `RCL`     | <code>C:A ← (C:A << B) &#124; (C:A >> -B)</code>       | `ZNC` | (1) (2) (3) |
+| `0 0000 1001` | `RCR`     | <code>A:C ← (A:C >> B) &#124; (A:C << -B)</code>       | `ZNC` | (1) (2) (3) |
+| `0 0000 1010` | `POPCNT`  | Counts the number of set bits in the `B` input         | `ZN`  | (4)         |
+| `0 0000 1011` | `BITSWAP` | Swaps all the bits based on the `SS` bits              | `ZN`  | (5)         |
+| `0 0000 1100` | `CTZ`     | Counts the number of `0` bits before the first `1` bit | `ZN`  |             |
+| `0 0000 1101` | `CLZ`     | Counts the number of `0` bits after the last `1` bit   | `ZN`  |             |
+| `0 0000 1110` | `NOT`     | <code>A ← ~B</code>                                    | `ZN`  |             |
+| `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38 B</code>                             | `ZN`  |             |
+
+1) C in the operation column refers to the carry flag.
+2) Only the `M` least significant bits of `B` (or `-B` where applicable) are used for a shift amount.
+    `M` is equal to 3, 4, 5, or 6 for SS values of 00, 01, 10, or 11 respectively.
+    After these operations, the carry flag contains the last bit shifted out of `A`. For example,
+    if `rh0` is `0x80`, then after `rolh rh0,1`, the carry flag will be set and `rh0` will be 1.
+    If the shift amount is 0, the carry flag is undefined.
+    In all cases, the Z and N flags are set according to the result written.
+    For example, if `rh0` is `0x80`, then after `rclh rh0,1`, the carry flag will be set,
+    `rh0` will be 0, the negative flag will be cleared, and the zero flag will be set.
+3) The notation C:A represents combining the carry flag with the value in register `A`. If the operation
+    size is `half`, the value is `C AAAA AAAA`, a 9-bit value. The `RCL` instruction rotates this 9-bit
+    value left. The `RCR` instruction rotates the value `AAAA AAAA C` to the right. The operation
+    is analogous for other operation sizes.
+4) The input is effectively zero extended based on the `SS` bits to ensure irrelevant bits are ignored
+5) All the bits are swapped so that the highest bits are the lowest and vice-a-versa. For `SS = 11` it
+    would act like this: `r[63] <-> r[0], r[62] <-> r[1], ..., r[32] <-> r[31]`. For `SS = 00` it would
+    act like this: `r[7] <-> r[0], r[6] <-> r[1], r[5] <-> r[2], r[4] <-> r[3]`.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -23,8 +23,8 @@ These instructions are in the expanded calculation opcode section of instruction
 | `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZN`  | (6)         |
 | `0 0000 1101` | `CLZ`     | <code>A ← CLZ(B)</code>                                | `ZN`  | (7)         |
 | `0 0000 1110` | `NOT`     | <code>A ← ~B</code>                                    | `ZN`  |             |
-| `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38 B</code>                             | `ZN`  |             |
-| `0 0001 1000` | `LSB`     | <code>A ← B &#38 -B</code>                             | `ZN`  |             |
+| `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38; B</code>                            | `ZN`  |             |
+| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZN`  |             |
 | `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZN`  |             |
 | `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZN`  |             |
 | `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  |             |

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -24,7 +24,7 @@ These instructions are in the expanded calculation opcode section of instruction
 | `0 0000 1101` | `CLZ`     | <code>A ← CLZ(B)</code>                                | `ZC`  | (7)         |
 | `0 0000 1110` | `NOT`     | <code>A ← ~B</code>                                    | `ZN`  |             |
 | `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38; B</code>                            | `ZN`  |             |
-| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZNC` |             |
+| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZN`  |             |
 | `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZNC` |             |
 | `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZNC` |             |
 | `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  |             |

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -16,34 +16,31 @@ These instructions are in the expanded calculation opcode section of instruction
 
 | `C CCCC CCCC` | NAME      | Operation                                              | Flags | Comment     |
 |---------------|-----------|--------------------------------------------------------|-------|-------------|
-| `0 0000 1000` | `RCL`     | <code>C:A ← (C:A << B) &#124; (C:A >> -B)</code>       | `ZNC` | (1) (2) (3) |
-| `0 0000 1001` | `RCR`     | <code>A:C ← (A:C >> B) &#124; (A:C << -B)</code>       | `ZNC` | (1) (2) (3) |
+| `0 0000 1000` | `RCL`     | <code>C:A ← (C:B << 1) &#124; (C:B >> -1)</code>       | `ZNC` | (1) (2) (3) |
+| `0 0000 1001` | `RCR`     | <code>A:C ← (B:C >> 1) &#124; (B:C << -1)</code>       | `ZNC` | (1) (2) (3) |
 | `0 0000 1010` | `POPCNT`  | <code>A ← POPCNT(B)</code>                             | `Z`   | (4)         |
 | `0 0000 1011` | `GREV`    | <code>A ← GREV(A, B)</code>                            | `ZN`  | (5)         |
-| `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZC`  | (6)         |
-| `0 0000 1101` | `CLZ`     | <code>A ← CLZ(B)</code>                                | `ZC`  | (7)         |
+| `0 0000 1100` | `CTZ`     | <code>A ← CTZ(B)</code>                                | `ZC`  | (6) (7)     |
+| `0 0000 1101` | `CLZ`     | <code>A ← CLZ(B)</code>                                | `ZC`  | (6) (8)     |
 | `0 0000 1110` | `NOT`     | <code>A ← ~B</code>                                    | `ZN`  |             |
 | `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38; B</code>                            | `ZN`  |             |
-| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZN`  |             |
-| `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZNC` |             |
-| `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZNC` |             |
-| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  |             |
+| `0 0001 1000` | `LSB`     | <code>A ← B &#38; -B</code>                            | `ZN`  | (9)         |
+| `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZNC` | (6) (10)    |
+| `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZNC` | (6) (11)    |
+| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  | (12)        |
 
 1) C in the operation column refers to the carry flag.
-2) Only the `M` least significant bits of `B` (or `-B` where applicable) are used for a shift amount.
-    `M` is equal to 3, 4, 5, or 6 for SS values of 00, 01, 10, or 11 respectively.
-    After these operations, the carry flag contains the last bit shifted out of `A`. For example,
-    if `rh0` is `0x80`, then after `rolh rh0,1`, the carry flag will be set and `rh0` will be 1.
-    If the shift amount is 0, the carry flag is undefined.
-    In all cases, the Z and N flags are set according to the result written.
-    For example, if `rh0` is `0x80`, then after `rclh rh0,1`, the carry flag will be set,
-    `rh0` will be 0, the negative flag will be cleared, and the zero flag will be set.
+2) The `-1` in the operation equivalently indicates a shift amount of one less than the operation size.
+   `rcl A, B` is nearly equivalent to `adc B, B`, except that the result is stored in operand `A`
+   and the `V` flag is undefined after the operation.
 3) The notation C:A represents combining the carry flag with the value in register `A`. If the operation
     size is `half`, the value is `C AAAA AAAA`, a 9-bit value. The `RCL` instruction rotates this 9-bit
-    value left. The `RCR` instruction rotates the value `AAAA AAAA C` to the right. The operation
-    is analogous for other operation sizes.
-4) Counts the number of set bits in `B` as if it were zero extended based on the `SS` bits.
-5) Performs the generalized swap operation on `A` based on the value in `B`. It acts as follows
+    value left. The `RCR` instruction rotates the value `AAAA AAAA C` to the right. Therefore, for
+    `rcl`, the `C` flag will be set to the most significant bit of the input, and for `rcl` it will be
+    set to the least significant bit of the input.
+   The operation is analogous for other operation sizes.
+5) Counts the number of set bits in `B` as if it were zero extended based on the `SS` bits.
+6) Performs the generalized swap operation on `A` based on the value in `B`. It acts as follows
 ```
 int64_t grev(int64_t a, int b, int ss)
 {
@@ -61,5 +58,26 @@ int64_t grev(int64_t a, int b, int ss)
 - Byte swap can be formulated in terms of GREV where B=24 (for `SS = 10`).
 - Bit Reverse can be formulated in terms of GREV where B=31 (for `SS = 10`).
 
-6) Counts the number of `0` bits before the first `1` bit
-7) Counts the number of `0` bits after the last `1` bit
+6) These operations set the carry flag if their input was 0,
+    and set the `Z` and/or `N` flags according to the result.
+7) Counts the number of `0` bits more significant than the most significant `1` bit.
+   If there is no such `1` bit, produces the operand size. For example,
+   `clzd r0, 0` results in `32` in `r0`, and `clzx r0, 0x0700` results in `5`.
+8) Counts the number of `0` bits less significant than the least-significant `1` bit.
+   `ctz A,B` behaves as the following sequence:
+```
+        mov    A,B
+        grev   A,-1
+        clz    A,A
+```
+9) Notes 9, 10, 11, and 12 give examples of the remaining operations; however the behavior
+    of these operations is fully specified in the table and comment (6).
+   `lsb` isolates the least significant `1` bit of `B`. For example, `lsbx r0, 0xFFA0`
+    will result in `0x0020` in `rx0`.
+11) Get a mask of all bits up to and including the least significant `1` bit of `B`.
+    If there is no such bit, the mask is `-1`. For example, `lsmskx r0, 0xFFA0`
+    will result in `0x003F` in `rx0`.
+12) Reset (set to `0`) the least significant `1` bit of `B`. For example,
+    `rlsbx r0, 0xFFA0` will result in `0xFF80` in `rx0`.
+13) Zero out the bits of `A` at higher bit indices at least `B`. For example,
+    if `0xABCD` is in `rx0`, then `zhibx r0, 7` results in `0x004D` in `rx0`.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -26,8 +26,8 @@ These instructions are in the expanded calculation opcode section of instruction
 | `0 0000 1111` | `ANDN`    | <code>A ← ~A &#38 B</code>                             | `ZN`  |             |
 | `0 0001 1000` | `LSB`     | <code>A ← B &#38 -B</code>                             | `ZN`  |             |
 | `0 0001 1001` | `LSMSK`   | <code>A ← B ^ (B - 1)</code>                           | `ZN`  |             |
-| `0 0001 1010` | `RLSB`    | <code>A ← B ;&#38 (B - 1)</code>                       | `ZN`  |             |
-| `0 0001 1011` | `ZHIB`    | <code>A ← A ;&#38 ((1 << B) - 1)</code>                | `ZN`  |             |
+| `0 0001 1010` | `RLSB`    | <code>A ← B &#38; (B - 1)</code>                       | `ZN`  |             |
+| `0 0001 1011` | `ZHIB`    | <code>A ← A &#38; ((1 << B) - 1)</code>                | `ZN`  |             |
 
 1) C in the operation column refers to the carry flag.
 2) Only the `M` least significant bits of `B` (or `-B` where applicable) are used for a shift amount.

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -47,12 +47,12 @@ These instructions are in the expanded calculation opcode section of instruction
 ```
 int64_t grev(int64_t a, int b, int ss)
 {
-    if (b &  1)           a = ((a & 0x55555555) <<  1) | ((a & 0xAAAAAAAA) >>  1);
-    if (b &  2)           a = ((a & 0x33333333) <<  2) | ((a & 0xCCCCCCCC) >>  2);
-    if (b &  4)           a = ((a & 0x0F0F0F0F) <<  4) | ((a & 0xF0F0F0F0) >>  4);
-    if (b &  8 && ss > 0) a = ((a & 0x00FF00FF) <<  8) | ((a & 0xFF00FF00) >>  8);
-    if (b & 16 && ss > 1) a = ((a & 0x0000FFFF) << 16) | ((a & 0xFFFF0000) >> 16);
-    if (b & 32 && ss > 2) a = ((a & 0x0000FFFF) << 32) | ((a & 0xFFFF0000) >> 32);
+    if (b &  1)           a = ((a & 0x5555_5555_5555_5555) <<  1) | ((a & 0xAAAA_AAAA_AAAA_AAAA) >>  1);
+    if (b &  2)           a = ((a & 0x3333_3333_3333_3333) <<  2) | ((a & 0xCCCC_CCCC_CCCC_CCCC) >>  2);
+    if (b &  4)           a = ((a & 0x0F0F_0F0F_0F0F_0F0F) <<  4) | ((a & 0xF0F0_F0F0_F0F0_F0F0) >>  4);
+    if (b &  8 && ss > 0) a = ((a & 0x00FF_00FF_00FF_00FF) <<  8) | ((a & 0xFF00_FF00_FF00_FF00) >>  8);
+    if (b & 16 && ss > 1) a = ((a & 0x0000_FFFF_0000_FFFF) << 16) | ((a & 0xFFFF_0000_FFFF_0000) >> 16);
+    if (b & 32 && ss > 2) a = ((a & 0x0000_0000_FFFF_FFFF) << 32) | ((a & 0xFFFF_FFFF_0000_0000) >> 32);
 
     return sign_extend(a, ss);
 }

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -35,12 +35,9 @@ This extension adds an expanded instruction format to allow for a larger number 
 | `0 0000 0011` | `ASR`           | `A ← A >>> B`                      | `ZNC`    | (3) (4)     |
 | `0 0000 0100` | `ROL`           | <code>A ← (A << B) &#124; (A >> -B)</code> | `ZNC` | (3)   |
 | `0 0000 0101` | `ROR`           | <code>A ← (A >> B) &#124; (A << -B)</code> | `ZNC` | (3)   |
-| `0 0000 0110` | `RCL`           | <code>C:A ← (C:A << B) &#124; (C:A >> -B)</code> | `ZNC` | (2) (3) (5) |
-| `0 0000 0111` | `RCR`           | <code>A:C ← (A:C >> B) &#124; (A:C << -B)</code> | `ZNC` | (2) (3) (5) |
-| `0 0000 1000` | `SHL`           | `A ← A << B`                       | `ZNC`   | (3)         |
-| `0 0000 1001` | `SHR`           | `A ← A >> B`                       | `ZNC`   | (3)         |
-| `0 0000 101x` |                 |                                    |        | reserved    |
-| `0 0000 11xx` |                 |                                    |        | reserved    |
+| `0 0000 0110` | `SHL`           | `A ← A << B`                       | `ZNC`   | (3)         |
+| `0 0000 0111` | `SHR`           | `A ← A >> B`                       | `ZNC`   | (3)         |
+| `0 0000 1xxx` |                 |                                    |        | reserved    |
 | `0 0001 xxxx` |                 |                                    |        | reserved    |
 | `0 001x xxxx` |                 |                                    |        | reserved    |
 | `0 01xx xxxx` |                 |                                    |        | reserved    |
@@ -60,10 +57,6 @@ This extension adds an expanded instruction format to allow for a larger number 
     `rh0` will be 0, the negative flag will be cleared, and the zero flag will be set.
 4) This is an arithmetic right shift, which shifts in the most significant bit of A instead of always
     shifting in 0.
-5) The notation C:A represents combining the carry flag with the value in register `A`. If the operation
-    size is `half`, the value is `C AAAA AAAA`, a 9-bit value. The `RCL` instruction rotates this 9-bit
-    value left. The `RCR` instruction rotates the value `AAAA AAAA C` to the right. The operation
-    is analogous for other operation sizes.
 
 Consider the `rclh` operation. Since only the 3 least significant bits
 of `B` are used to determine shift amounts,


### PR DESCRIPTION
The only instruction missing from x86's BMI1 is `BEXTR`, but that requires 3 arguments. Instead of `BEXTR`, I've included `BZHI` which from BMI2