### PR TITLE
Cache update

### DIFF
--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -29,6 +29,11 @@ If this extension is present on a system without a data cache, `ALLOC_ZERO` _mus
 
 `ALLOC_ZERO` and `DCACHE_INVALIDATE` ignore the `SS` bits and the value in the `A` register is treated as address-sized.
 
+# Added Instruction Prefixes
+
+This extension adds the prefix `BYPASS_CACHE` with binary value `1101 0000`. This prefix causes the instruction it prefixes to bypass the cache when reading from or writing to memory.
+If the interrupt extension is present and this prefix is used with a cache instruction or an instruction that does not access memory, an `Illegal Instruction` exception should occur.
+
 # Added Control Registers
 
 | CRN      | Name               |

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -38,7 +38,7 @@ If this extension is present on a system without a data cache, `ALLOC_ZERO` _mus
 | `1 0000` | `NO_CACHE_END`    |
 
 `CACHE_LINE_SIZE` is a read-only control register which specifies the number of bytes in a cache line for the data cache. It _must_ be a power of 2 unless no data cache is present
-in which case it _may_ be 0.
+in which case it _must_ be 0.
 
 `NO_CACHE_START` is a cache-aligned address which represents the inclusive start of a contiguous range of physical memory addresses which will not be cached when accessed. If the privilege extension is present, this is only accessible in system mode.
 This control register is set to 0 on CPU initialization.

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -7,8 +7,8 @@
 # Overview
 
 This extension adds several instructions which can be used to control the data and instruction cache if they are present. While the `ALLOC_ZERO` instruction _must_ appear like
-a write of 0 to the specified address, the other 7 instructions _may_ be implemented as NOP instructions. This extension does __NOT__ require that an instruction or data cache
-is present.
+a write of 0 to the cache line specified by the address, the other 7 instructions _may_ be implemented as NOP instructions. This extension does __NOT__ require that an instruction
+cache or data cache is present.
 
 # Added Instructions
 
@@ -23,10 +23,9 @@ is present.
 | `DCACHE_FLUSH`         | `1001 1111`  | `AAA 000 10` | Flushes the data cache entry for the address specified by the A register.                                               |
 | `ICACHE_INVALIDATE`    | `1001 1111`  | `AAA 000 11` | Invalidates the instruciton cache entry for the address specified by the A register.                                    |
 
-Note that the last 5 instructions overlap with the never jump instruction. This is intentional since these instructions don't change a programs behavior.
+Note that the last 5 instructions overlap with the never jump instruction. This is intentional since these instructions shouldn't change the behavior of a program.
 
-If this extension is present on a system without a data cache, `ALLOC_ZERO` must write 0 to memory as if it had a cache line size as specified by the `CACHE_LINE_SIZE` control register.
-If `CACHE_LINE_SIZE` is zero, then it _must_ be a NOP instruction.
+If this extension is present on a system without a data cache, `ALLOC_ZERO` _must_ be a NOP instruction.
 
 `ALLOC_ZERO` and `DCACHE_INVALIDATE` ignore the `SS` bits and the value in the `A` register is treated as address-sized.
 

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -23,11 +23,15 @@ cache or data cache is present.
 | `DCACHE_FLUSH`         | `1001 1111`  | `AAA 000 10` | Flushes the data cache entry for the address specified by the A register.                                               |
 | `ICACHE_INVALIDATE`    | `1001 1111`  | `AAA 000 11` | Invalidates the instruciton cache entry for the address specified by the A register.                                    |
 
-Note that the last 5 instructions overlap with the never jump instruction. This is intentional since these instructions shouldn't change the behavior of a program.
-
-If this extension is present on a system without a data cache, `ALLOC_ZERO` _must_ be a NOP instruction.
+Note that the last 5 instructions overlap with the never jump instruction. This is intentional since these instructions shouldn't change the behavior of a program in most cases.
 
 `ALLOC_ZERO` and `DCACHE_INVALIDATE` ignore the `SS` bits and the value in the `A` register is treated as address-sized.
+
+### Special cases for implementations
+
+- On a system without a data cache, `ALLOC_ZERO` _must_ be a NOP instruction.
+- On a system with an instruction cache which is not fully synchronized with the data cache (or memory when a data cache is not present), `ICACHE_INVALIDATE` _must_ not be a NOP instruction.
+- On a system with an instruction cache which is not fully synchronized with the data cache (or memory when a data cache is not present), `CACHE_INVALIDATE_ALL` _must_ not be a NOP instruction.
 
 # Added Instruction Prefixes
 

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -33,11 +33,6 @@ Note that the last 5 instructions overlap with the never jump instruction. This 
 - On a system with an instruction cache which is not fully synchronized with the data cache (or memory when a data cache is not present), `ICACHE_INVALIDATE` _must_ not be a NOP instruction.
 - On a system with an instruction cache which is not fully synchronized with the data cache (or memory when a data cache is not present), `CACHE_INVALIDATE_ALL` _must_ not be a NOP instruction.
 
-# Added Instruction Prefixes
-
-This extension adds the prefix `BYPASS_CACHE` with binary value `1101 0000`. This prefix causes the instruction it prefixes to bypass the cache when reading from or writing to memory.
-If the interrupt extension is present and this prefix is used with a cache instruction or an instruction that does not access memory, an `Illegal Instruction` exception should occur.
-
 # Added Control Registers
 
 | CRN      | Name               |

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -7,7 +7,7 @@
 # Overview
 
 This extension adds several instructions which can be used to control the data and instruction cache if they are present. While the `ALLOC_ZERO` instruction _must_ appear like
-a write of 0 to the cache line specified by the address, the other 7 instructions _may_ be implemented as NOP instructions. This extension does __NOT__ require that an instruction
+a write of 0 to the cache line specified by the address, the other 7 instructions _may_ be implemented as NOP instructions (see exceptions below). This extension does __NOT__ require that an instruction
 cache or data cache is present.
 
 # Added Instructions

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -7,7 +7,7 @@
 # Overview
 
 This extension adds several instructions which can be used to control the data and instruction cache if they are present. While the `ALLOC_ZERO` instruction _must_ appear like
-a write of 0 to the cache line specified by the address, the other 7 instructions _may_ be implemented as NOP instructions (see exceptions below). This extension does __NOT__ require that an instruction
+a write of 0 to the cache line specified by the address, the other 7 instructions _may_ be implemented as NOP instructions (see special cases below). This extension does __NOT__ require that an instruction
 cache or data cache is present.
 
 # Added Instructions

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -30,9 +30,5 @@ Unless specified otherwise, each prefix can only be used _at most_ once per inst
 |:------------|:--------------------------------------------------------------|
 | `1010 xxxx` | When `xxxx` is neither `1110` nor `1111`, conditional prefix. |
 | `1100 xxxx` | Expanded registers prefix and large immediate bit.            |
-| `1101 0000` | Cache bypass prefix.                                          |
-| `1101 0001` | Unused                                                        |
-| `1101 001x` | Unused                                                        |
-| `1101 01xx` | Unused                                                        |
-| `1101 1xxx` | Unused                                                        |
+| `1101 xxxx` | Unused                                                        |
 

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -20,7 +20,6 @@ Instruction prefixes are a sequence of one or more bytes which modify the instru
 
 1. Conditional Prefix
 2. Expanded Registers
-3. Cache Bypass
 
 Unless specified otherwise, each prefix can only be used _at most_ once per instruction.
 

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -29,5 +29,9 @@ Unless specified otherwise, each prefix can only be used _at most_ once per inst
 |:------------|:--------------------------------------------------------------|
 | `1010 xxxx` | When `xxxx` is neither `1110` nor `1111`, conditional prefix. |
 | `1100 xxxx` | Expanded registers prefix and large immediate bit.            |
-| `1101 xxxx` | Unused                                                        |
+| `1101 0000` | Cache bypass prefix.                                          |
+| `1101 0001` | Unused                                                        |
+| `1101 001x` | Unused                                                        |
+| `1101 01xx` | Unused                                                        |
+| `1101 1xxx` | Unused                                                        |
 

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -20,6 +20,7 @@ Instruction prefixes are a sequence of one or more bytes which modify the instru
 
 1. Conditional Prefix
 2. Expanded Registers
+3. Cache Bypass
 
 Unless specified otherwise, each prefix can only be used _at most_ once per instruction.
 


### PR DESCRIPTION
- Modifies the behavior of `alloc_zero` on systems without a data cache
- Restricts the values that the `cache_line_size` CR can have on systems without a data cache
- ~~Add a prefix bypassing the cache on systems with a data cache.~~