### PR TITLE
Fix all the missing dots I can see.

### DIFF
--- a/base-isa.md
+++ b/base-isa.md
@@ -13,10 +13,10 @@ This is a group of 16 bit fixed width instructions.
 
 The highest two bits of the first byte are a format marker:
 
-- `00` this is a computation operation between two registers
-- `01` this is a computation operation between a register and an immediate
-- `10` this is a (conditional) jump instruction
-- `11` this is a variable length instruction and reserved for extensions
+- `00` this is a computation operation between two registers.
+- `01` this is a computation operation between a register and an immediate.
+- `10` this is a (conditional) jump instruction.
+- `11` this is a variable length instruction and reserved for extensions.
 
 # Overview
 
@@ -60,7 +60,12 @@ The second byte has the format `AAA BBB MM` where `AAA` and `BBB` are references
 
 ### Immediate Computation
 
-The second byte has the format `AAA IIIII`, where the 5 bit immediate acts as operand `B`. The immediate is sign extended for operations 0-7 and operation 9. The immediate is zero extended for operation 8 and operations 10-15. `AAA` is treated the same as in the 2 Register Computation section above.
+The second byte has the format `AAA IIIII`, where the 5 bit immediate acts as operand `B`. `AAA` is treated the same as in the 2 Register Computation section above.
+
+
+For operations 8 and operation 10-15, immediate arguments are zero extended.
+For **all** other operations, including those from extensions, immediate arguments
+are sign extended.
 
 ### Exceptions
 
@@ -69,7 +74,7 @@ There are several exceptions to how the operands work.
  - `RSUB`
     - The `B` operand is the left source register and the `A` operand is the right source register.
  - `CMP` and `TEST`
-    - These instructions do not have a destination register
+    - These instructions do not have a destination register.
  - `STORE`
     - This instruction uses the `B` operand to specify which memory address is written to.
  - `WRITECR`

--- a/extensions/bit-manipulation-1/README.md
+++ b/extensions/bit-manipulation-1/README.md
@@ -39,7 +39,7 @@ These instructions are in the expanded calculation opcode section of instruction
    will be clear because a `0` was shifted out of `0x02`.
    The operation is analogous for other operation sizes.
 5) Counts the number of set bits in `B` as if it were zero extended based on the `SS` bits.
-6) Performs the generalized swap operation on `A` based on the value in `B`. It acts as follows
+6) Performs the generalized swap operation on `A` based on the value in `B`. It acts as follows.
 ```
 int64_t grev(int64_t a, int b, int ss)
 {

--- a/extensions/cache-instructions/README.md
+++ b/extensions/cache-instructions/README.md
@@ -54,5 +54,5 @@ This control register is set to `-CACHE_LINE_SIZE` on CPU initialization.
 
 - The purpose of the initial values for these control registers is to intially disable caching since the location of MMIO is unknown.
 - When writing to these control registers, the value will be sign extended from the write width to the maxiumum supported physical address width.
-- Writing a non-cache-aligned value is _unspecified_ behavior
+- Writing a non-cache-aligned value is _unspecified_ behavior.
 - If `NO_CACHE_START` is larger than `NO_CACHE_END`, the non-cacheable address range wraps past the end of the address space back to the beginning.

--- a/extensions/double-word-operations/README.md
+++ b/extensions/double-word-operations/README.md
@@ -4,18 +4,18 @@
 **Requires: Base**  
 **CPUID Bit: CP1.14**
 
-- All registers (excluding the `PC`) _must_ be able to store 32 bit (double word) values
+- All registers (excluding the `PC`) _must_ be able to store 32 bit (double word) values.
 - The SS bits in the calculation opcode can now be set to 10.
 - When the SS bits are set to 10, the calculation is performed as if the operation was for 32 bit values.
 - Operations that write to a register _must_ sign extend the value to the register's width before writing it to the register _unless_ the operation is `movz` in which case it _must_ zero extend the value to the register's width before writing it to the register.
 - Operations that modify flags _must_ modify them as if the operation was for 32 bit values.
 - Memory stores in this mode _must_ only affect the 32 bit section that is being written to.
-- Memory stores with the SS bits set to 01 _must_ only affect the 16 bit section that is being written to
-- Memory address alignment in this mode is 4 bytes
+- Memory stores with the SS bits set to 01 _must_ only affect the 16 bit section that is being written to.
+- Memory address alignment in this mode is 4 bytes.
 
 # Assembly changes
 
-32 bit register references/32 bit operations are marked by the infix/prefix `d` (i.e. `%rd0`)
+32 bit register references/32 bit operations are marked by the infix/prefix `d` (i.e. `%rd0`).
 
 # Memory semantics
 

--- a/extensions/expanded-opcodes/README.md
+++ b/extensions/expanded-opcodes/README.md
@@ -64,10 +64,6 @@ of `B` are used to determine shift amounts,
 different if a count of 8 were allowed! To achieve the result that a count
 of 8 _would_ obtain, instead perform `rcrh _,1`.
 
-### Implementor's Notice:
-
-There is a tentative plan to move the `rcl` and `rcr` instructions to the BM1 extension, when it receives its initial specification. This is due to their increased implementation complexity. For now, a compliant implementation of this extension _must_ provide them.
-
 ## Jump and Call
 
 | First byte    | 2nd-9th Byte | Comment                                                             |

--- a/extensions/full-immediates/README.md
+++ b/extensions/full-immediates/README.md
@@ -44,8 +44,8 @@ the following table:
 
 If the [register expansion](../expanded-registers/README.md) extension is available, then `REX.Q` can be used with instructions from this
 extension. It has an effect only if both of the following conditions are met:
-  - The instruction has an `iS` operand
-  - The instruction's operand size attribute is `quad`
+  - The instruction has an `iS` operand, and
+  - The instruction's operand size attribute is `quad`.
 Then the immediate is an 8-byte literal value instead of a 4-byte literal value.
 
 Sign extension of the immediate follows the same rules as used for 5 bit immediates in register-immediate mode.

--- a/extensions/half-word-operations/README.md
+++ b/extensions/half-word-operations/README.md
@@ -9,12 +9,12 @@
 - Operations that write to a register _must_ sign extend the value to the register's width before writing it to the register _unless_ the operation is `movz` in which case it _must_ zero extend the value to the register's width before writing it to the register.
 - Operations that modify flags _must_ modify them as if the operation was for 8 bit values.
 - Memory stores in this mode _must_ only affect the 8 bit section that is being written to.
-- Memory address alignment in this mode is 1 byte
+- Memory address alignment in this mode is 1 byte.
 
 
 # Assembly changes
 
-8 bit register references/8 bit operations are marked by the infix/prefix `h` (i.e. `%rh0`)
+8 bit register references/8 bit operations are marked by the infix/prefix `h` (i.e. `%rh0`).
 
 # Memory semantics
 

--- a/extensions/interrupts/README.md
+++ b/extensions/interrupts/README.md
@@ -35,7 +35,7 @@ must trigger a #GP fault.
 
 ## Flags CR
 
-The following table specifies which flag is associated with which bit in the `FLAGS` CR. Unused bits are reserved for future extensions
+The following table specifies which flag is associated with which bit in the `FLAGS` CR. Unused bits are reserved for future extensions.
 
 | Bit | Flag     |
 |-----|----------|

--- a/extensions/memory-operands-1/README.md
+++ b/extensions/memory-operands-1/README.md
@@ -46,8 +46,8 @@ A `dP` is the same size as a logical address in the current mode. However, simil
 this extension cannot encode an 8 byte displacement. In `quadword` address mode, a `dP` is 4 bytes.
 
 If the [register expansion](../expanded-registers/README.md) extension is available, then `REX.Q` may be used with instructions in these formats if
-  - The instruction contains a `dP`
-  - The current Addressing Mode is `quadword`
+  - The instruction contains a `dP`, and
+  - The current Addressing Mode is `quadword`.
 
 In this case, the `dP` is an 8-byte value rather than a 4-byte value.
 

--- a/extensions/memory-operands-2/README.md
+++ b/extensions/memory-operands-2/README.md
@@ -51,11 +51,11 @@ and may change in the future when we are better able to evaluate the waste.
 ## `REX.Q`
 
 A `REX.Q` prefix can be used with instructions in this format if:
+  - The [register expansion](../expanded-registers/README.md) extension is available.
   - The instruction has _exactly one_ of a displacement or immediate. It cannot have both.
   - either:
-    - The instruction is an `iS` mode with Operand Size attribute `quad`
-    - The instruction is a `dP` mode and the current Addressing Mode is `quad`
-  - The [register expansion](../expanded-registers/README.md) extension is available
+    - The instruction is an `iS` mode with Operand Size attribute `quad`, or
+    - The instruction is a `dP` mode and the current Addressing Mode is `quad`.
 
 Then the `iS` or `dP` will be an 8-byte value rather than a 4-byte value.
 

--- a/extensions/privileged-mode/README.md
+++ b/extensions/privileged-mode/README.md
@@ -51,6 +51,6 @@ In order to handle an interrupt, the CPU _must_ also do the following beforehand
 1. Set the `INT_RET_PRIV` CR to the current `PRIV` CR.
 2. Set the `PRIV` CR to 1.
 
-When the `IRET` instruction is encountered, the following _must_ also occur
+When the `IRET` instruction is encountered, the following _must_ also occur.
 
 1. Set the `PRIV` CR to the `INT_RET_PRIV` CR.

--- a/extensions/quad-word-operations/README.md
+++ b/extensions/quad-word-operations/README.md
@@ -4,14 +4,14 @@
 **Requires: Base**  
 **CPUID Bit: CP1.15**
 
-- All registers (excluding the `PC`) _must_ be able to store 64 bit (quad word) values
+- All registers (excluding the `PC`) _must_ be able to store 64 bit (quad word) values.
 - The SS bits in the calculation opcode can now be set to 11.
 - When the SS bits are set to 11, the calculation is performed as if the operation was for 64 bit values.
 - Operations that write to a register _must_ sign extend the value to the register's width before writing it to the register _unless_ the operation is `movz` in which case it _must_ zero extend the value to the register's width before writing it to the register.
 - Operations that modify flags _must_ modify them as if the operation was for 64 bit values.
 - Memory stores in this mode _must_ only affect the 64 bit section that is being written to.
-- Memory stores with the SS bits set to 01 _must_ only affect the 16 bit section that is being written to
-- Memory address alignment in this mode is 8 bytes
+- Memory stores with the SS bits set to 01 _must_ only affect the 16 bit section that is being written to.
+- Memory address alignment in this mode is 8 bytes.
 
 # Assembly changes
 

--- a/extensions/variable-width-instruction-standard.md
+++ b/extensions/variable-width-instruction-standard.md
@@ -8,11 +8,11 @@ Variable Width Instructions (VWI) are a sequence of one or more bytes which coun
 
 Note that this does not preclude pipelining, so long as any references to the instruction pointer in the specification of an instruction correctly refer to the base address of that instruction being executed.
 
-If the first byte of an instruction is `11xx xxxx`, it is a VWI
+If the first byte of an instruction is `11xx xxxx`, it is a VWI.
 
 ## Single Byte NOP
 
-All CPUs which support at least 1 VWI extension must also accept `1010 1110` as a single byte NOP instruction
+All CPUs which support at least 1 VWI extension must also accept `1010 1110` as a single byte NOP instruction.
 
 ## Instruction Prefixes
 
@@ -29,5 +29,5 @@ Unless specified otherwise, each prefix can only be used _at most_ once per inst
 |:------------|:--------------------------------------------------------------|
 | `1010 xxxx` | When `xxxx` is neither `1110` nor `1111`, conditional prefix. |
 | `1100 xxxx` | Expanded registers prefix and large immediate bit.            |
-| `1101 xxxx` | Unused                                                        |
+| `1101 xxxx` | Unused.                                                       |
 

--- a/features/multiple-memory-access-instructions/README.md
+++ b/features/multiple-memory-access-instructions/README.md
@@ -5,7 +5,7 @@
 
 * The memory instructions, including but not limited to `store`, `load`, `push`, and `pop`, _must_ accept memory operands as specified by the `MO1` and `MO2` extensions.
     * The stack pointer for `push` and `pop` may only be a memory operand if the [../extensions/arbitrary-stack-pointer](Arbitrary Stack Pointer) extension is implemented.
-* The `pop` instruction _must_ be treated as an _illegal_ instruction when the RMI byte follows the pattern `xxx 00x 01`.
+* The `pop` instruction _must_ be treated as an _illegal_ instruction when the RMI byte follows the pattern `xxx 0xx 01`.
     * This prevents using an immediate as the stack pointer.
 
 ### Concept

--- a/rationale.md
+++ b/rationale.md
@@ -3,7 +3,8 @@
 ETC.A is a community-owned public/open source/what have you Instruction Set Architecture. It is developed by the community of the Turing Complete game. We have a few goals:
 1) [bare-metal] Being designed for the purpose of having a well-standardized architecture for use in community programming challenges.
 2) [approachable] In the most restricted form, be simple enough that newcomers can get involved easily.
-3) [extensible] Flexible enough to be extensible (The name, ETC.A, stands for "extensible turing complete architecture"). Code assembled for a hardware with some set of extensions should run on _any_ hardware with a superset of those extensions.
+3) [extensible] Flexible enough to be extensible (The name, ETCa, stands for "extensible turing complete architecture").
+Code assembled for a hardware with some set of extensions should run on _any_ hardware with a superset of those extensions.
 4) [educational] Be interesting, allowing for features and hardware implementations that have educational value.
 5) [practicality] Be practical; if in 30 years someone wants to build and use a machine for the ISA, that should be not only reasonable but natural.
 6) [common cases] The most common cases of instructions should have a shorter encoding, if possible.
@@ -20,8 +21,7 @@ Less common cases can be emulated with the compact instructions, but will have a
 The most common cases of many types of instructions cannot arise in the base ISA. One of the most common instructions in typical x86 assembly is `call`, which the base ISA
 does not even have. Most (but not all) of the reserved space is reserved for such common instructions which do not make sense in the base ISA. The bits labeled `SS` are reserved
 as _size bits_, allowing an instruction to have an operational width of 1, 2, 4, or 8 bytes. One of the bits near the jump format is reserved for turning jumps into
-calls, while another is for indirect jumps. We are not yet sure what we want to use the two LSBs of the operand byte for, but some ideas include a mode switch similar to
-x86's `MOD R/M` byte.
+calls, while another is for indirect jumps. The two least significant bits of the operand byte are reserved for fancy "memory operands."
 
 The most significant bits of the opcode byte being `11` are reserved for any extensions to use as is relevant to them.
 
@@ -48,8 +48,8 @@ The spec dictates that the value of the C and O flags is implementation-dependen
 keep their old values. The original microprocessors (such as the Intel 8008/8008-1) did actually work this way. It was determined to be confusing. Additionally, it is more
 useful for such operations to provide an easy way to clear the C flag.
 
-There is another very important reason for not keeping the old values. Very advanced processors, called _superscalar processors_, are capable of executing instructions in
-a different order than they appear in the program binary, as long as the behavior of the program is unchanged. If flags could keep their own values even through instructions
+There is another very important reason for not keeping the old values. Very advanced processors are capable of executing instructions in
+a different order than they appear in the program binary, as long as the behavior of the program is unchanged. If flags could keep their old values even through instructions
 that modify the flags, then the dependency chain of instructions referring to the flags (called "data hazards") becomes very complicated and hard to track, preventing
 out-of-order execution on some cases where it should be possible.
 
@@ -68,13 +68,13 @@ Any useful "practical" general-purpose processor must support executing programs
 it as executable, and then execute it.
 
 However, getting this right is difficult for newcomers. The possibility of an instruction reading from its own address means that memory contention is already
-possible in the base ISA. For many people coming from the Turing Complete game, such memory conention is a completely new challenge. As such, the base ISA only specifies
+possible in the base ISA. For many people coming from the Turing Complete game, such memory contention is a completely new challenge. As such, the base ISA only specifies
 undefined behavior in these cases. The intent is that such machines will treat their whole address space as available RAM while reading instructions from separate memory.
 This is also a useful anti-specification for a future in embedded devices. Embedded devices are frequently tiny and can be more easily built if the program is known,
 stored in a ROM, and divided from data memory. By not requiring executable RAM, we ensure that programs can be compatible across a wider range of spec-compliant
 bare metal devices.
 
-Of course, an extension will indicate that the processor supports executable RAM.
+Of course, the [VON Feature](features/von-neumann/) exists to indicate that the processor supports executable RAM.
 
 ### Placement of Extensions
 


### PR DESCRIPTION
I also slightly modernized some files, but only where the changes were fairly small:

BASE-ISA: Clarify extension of immediates as recently discussed on Discord.
EXOP: Removed mention of rcl and rcr, which have already moved to BM1.
RATIONALE: This file was humorously outdated. Now it is better.

All other changed files have only added periods or slight grammatical/stylistic adjustments to lists.